### PR TITLE
Moved the logic around RunCommand from DeviceClient into AdbFileSystem

### DIFF
--- a/caching_device_client_test.go
+++ b/caching_device_client_test.go
@@ -25,7 +25,7 @@ func TestNewCachedDirEntries(t *testing.T) {
 func TestCachingDeviceClientStat_Miss(t *testing.T) {
 	client := &CachingDeviceClient{
 		DeviceClient: &delegateDeviceClient{
-			stat: func(path string, _ *LogEntry) (*goadb.DirEntry, error) {
+			stat: func(path string) (*goadb.DirEntry, error) {
 				if path == "/foo/bar" {
 					return &goadb.DirEntry{Name: "baz"}, nil
 				}
@@ -80,7 +80,7 @@ func TestCachingDeviceClientStat_HitNotExists(t *testing.T) {
 func TestCachingDeviceClientStat_Root(t *testing.T) {
 	client := &CachingDeviceClient{
 		DeviceClient: &delegateDeviceClient{
-			stat: func(path string, _ *LogEntry) (*goadb.DirEntry, error) {
+			stat: func(path string) (*goadb.DirEntry, error) {
 				if path == "/" {
 					return &goadb.DirEntry{Name: "/"}, nil
 				}

--- a/device_client_test.go
+++ b/device_client_test.go
@@ -2,86 +2,29 @@ package adbfs
 
 import (
 	"io"
-	"testing"
 
-	"github.com/hanwen/go-fuse/fuse"
-	"github.com/stretchr/testify/assert"
 	"github.com/zach-klippenstein/goadb"
 )
 
 type delegateDeviceClient struct {
-	openRead       func(path string, log *LogEntry) (io.ReadCloser, error)
-	stat           func(path string, log *LogEntry) (*goadb.DirEntry, error)
-	listDirEntries func(path string, log *LogEntry) ([]*goadb.DirEntry, error)
-	readLink       func(path, rootPath string, log *LogEntry) (string, error, fuse.Status)
+	openRead       func(path string) (io.ReadCloser, error)
+	stat           func(path string) (*goadb.DirEntry, error)
+	listDirEntries func(path string) ([]*goadb.DirEntry, error)
+	runCommand     func(cmd string, args []string) (string, error)
 }
 
-func (c *delegateDeviceClient) OpenRead(path string, log *LogEntry) (io.ReadCloser, error) {
-	return c.openRead(path, log)
+func (c *delegateDeviceClient) OpenRead(path string, _ *LogEntry) (io.ReadCloser, error) {
+	return c.openRead(path)
 }
 
-func (c *delegateDeviceClient) Stat(path string, log *LogEntry) (*goadb.DirEntry, error) {
-	return c.stat(path, log)
+func (c *delegateDeviceClient) Stat(path string, _ *LogEntry) (*goadb.DirEntry, error) {
+	return c.stat(path)
 }
 
-func (c *delegateDeviceClient) ListDirEntries(path string, log *LogEntry) ([]*goadb.DirEntry, error) {
-	return c.listDirEntries(path, log)
+func (c *delegateDeviceClient) ListDirEntries(path string, _ *LogEntry) ([]*goadb.DirEntry, error) {
+	return c.listDirEntries(path)
 }
 
-func (c *delegateDeviceClient) ReadLink(path, rootPath string, log *LogEntry) (string, error, fuse.Status) {
-	return c.readLink(path, rootPath, log)
-}
-
-func TestReadLinkFromDevice_AbsoluteTarget(t *testing.T) {
-	target, err, status := readLinkFromDevice("version_link.txt", "/foo/bar",
-		func(cmd string, args ...string) (string, error) {
-			if cmd == "readlink" && args[0] == "version_link.txt" {
-				return "/version.txt\r\n", nil
-			}
-			t.Fatal("invalid command:", cmd, args)
-			return "", nil
-		})
-	assert.NoError(t, err)
-	assertStatusOk(t, status)
-	assert.Equal(t, "/foo/bar/version.txt", target)
-}
-
-func TestReadLinkFromDevice_RelativeTarget(t *testing.T) {
-	target, err, status := readLinkFromDevice("version_link.txt", "/foo/bar",
-		func(cmd string, args ...string) (string, error) {
-			if cmd == "readlink" && args[0] == "version_link.txt" {
-				return "version.txt\r\n", nil
-			}
-			t.Fatal("invalid command:", cmd, args)
-			return "", nil
-		})
-	assert.NoError(t, err)
-	assertStatusOk(t, status)
-	assert.Equal(t, "version.txt", target)
-}
-
-func TestReadLinkFromDevice_NotALink(t *testing.T) {
-	_, err, status := readLinkFromDevice("version.txt", "",
-		func(cmd string, args ...string) (string, error) {
-			if cmd == "readlink" && args[0] == "version.txt" {
-				return ReadlinkInvalidArgument, nil
-			}
-			t.Fatal("invalid command:", cmd, args)
-			return "", nil
-		})
-	assert.Error(t, err)
-	assert.Equal(t, fuse.EINVAL, status)
-}
-
-func TestReadLinkFromDevice_PermissionDenied(t *testing.T) {
-	_, err, status := readLinkFromDevice("version_link.txt", "",
-		func(cmd string, args ...string) (string, error) {
-			if cmd == "readlink" && args[0] == "version_link.txt" {
-				return ReadlinkPermissionDenied, nil
-			}
-			t.Fatal("invalid command:", cmd, args)
-			return "", nil
-		})
-	assert.NoError(t, err)
-	assert.Equal(t, fuse.EPERM, status)
+func (c *delegateDeviceClient) RunCommand(cmd string, args ...string) (string, error) {
+	return c.runCommand(cmd, args)
 }


### PR DESCRIPTION
Keeps DeviceClient a simple mockable interface.