### PR TITLE
Implemented a custom nodefs.File.

### DIFF
--- a/adb_file.go
+++ b/adb_file.go
@@ -1,14 +1,94 @@
 package adbfs
 
-import "github.com/hanwen/go-fuse/fuse/nodefs"
+import (
+	"fmt"
+	"io"
 
-// AdbFile is a nodefs.File that is backed by a file on an adb device.
-type AdbFile struct {
-	nodefs.File
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
+)
+
+type AdbFileOpenOptions struct {
+	Flags      FileOpenFlags
+	FileBuffer *FileBuffer
 }
 
-func NewAdbFile() nodefs.File {
-	return nodefs.NewReadOnlyFile(&AdbFile{
-		File: nodefs.NewDefaultFile(),
-	})
+/*
+AdbFile is a nodefs.File that is backed by a file on an adb device.
+There is one AdbFile for each file descriptor. All AdbFiles that point to the same
+path are backed by the same FileBuffer.
+
+Note: On OSX at least, the OS will automatically map multiple open files to a single AdbFile.
+*/
+type AdbFile struct {
+	nodefs.File
+	AdbFileOpenOptions
+}
+
+var _ nodefs.File = &AdbFile{}
+
+// NewAdbFile returns a File that reads and writes to name on the device.
+// perms should be set from the existing file if it exists, or to the desired new permissions if new.
+func NewAdbFile(opts AdbFileOpenOptions) nodefs.File {
+	logEntry := StartFileOperation("New", opts.FileBuffer.Path, fmt.Sprint(opts))
+	defer logEntry.FinishOperation()
+
+	adbFile := &AdbFile{
+		// Log all the operations we don't implement.
+		File:               newLoggingFile(nodefs.NewDefaultFile(), opts.FileBuffer.Path),
+		AdbFileOpenOptions: opts,
+	}
+
+	return nodefs.NewReadOnlyFile(adbFile)
+}
+
+func (f *AdbFile) startFileOperation(name string, args string) *LogEntry {
+	return StartFileOperation(name, f.FileBuffer.Path, args)
+}
+
+func (f *AdbFile) InnerFile() nodefs.File {
+	return f.File
+}
+
+func (f *AdbFile) Release() {
+	logEntry := f.startFileOperation("Release", "")
+	defer logEntry.FinishOperation()
+
+	// Cleanup the underlying buffer after the last open file is closed.
+	f.FileBuffer.DecRefCount()
+}
+
+func (f *AdbFile) Read(buf []byte, off int64) (fuse.ReadResult, fuse.Status) {
+	logEntry := f.startFileOperation("Read", formatArgsListForLog(buf, off))
+	defer logEntry.FinishOperation()
+
+	if !f.Flags.CanRead() {
+		return readResultError(fuse.EPERM), logEntry.Status(fuse.EPERM)
+	}
+
+	n, err := f.FileBuffer.ReadAt(buf, off)
+	if err == io.EOF {
+		err = nil
+	}
+
+	logEntry.Result("read %d bytes", n)
+	return fuse.ReadResultData(buf[:n]), toFuseStatus(err, logEntry)
+}
+
+// Fsync re-reads the file from the device into memory.
+func (f *AdbFile) Fsync(flags int) fuse.Status {
+	logEntry := f.startFileOperation("Fsync", formatArgsListForLog(flags))
+	defer logEntry.FinishOperation()
+
+	err := f.FileBuffer.Sync(logEntry)
+	return toFuseStatus(err, logEntry)
+}
+
+func (f *AdbFile) GetAttr(out *fuse.Attr) fuse.Status {
+	logEntry := f.startFileOperation("GetAttr", "")
+	defer logEntry.FinishOperation()
+
+	// This operation doesn't require a read flag.
+
+	return logEntry.Status(getAttr(f.FileBuffer.Path, f.FileBuffer.Client, logEntry, out))
 }

--- a/adb_file_test.go
+++ b/adb_file_test.go
@@ -1,0 +1,101 @@
+package adbfs
+
+import (
+	"testing"
+
+	"github.com/hanwen/go-fuse/fuse"
+	"github.com/hanwen/go-fuse/fuse/nodefs"
+	"github.com/stretchr/testify/assert"
+	"github.com/zach-klippenstein/goadb/util"
+)
+
+func TestAdbFile_InnerFile(t *testing.T) {
+	file := getAdbFile(NewAdbFile(AdbFileOpenOptions{
+		FileBuffer: testSingleRegularFileBuffer(t, ""),
+	}))
+
+	assert.NotNil(t, file.InnerFile())
+	assert.IsType(t, &WrappingFile{}, file.InnerFile())
+}
+
+func TestAdbFile_Release(t *testing.T) {
+	fileBuf := testSingleRegularFileBuffer(t, "")
+	fileBuf.IncRefCount()
+	file := getAdbFile(NewAdbFile(AdbFileOpenOptions{
+		FileBuffer: fileBuf,
+	}))
+	file.Release()
+
+	assert.Equal(t, 0, fileBuf.RefCount())
+}
+
+func TestAdbFile_GetAttr(t *testing.T) {
+	file := getAdbFile(NewAdbFile(AdbFileOpenOptions{
+		FileBuffer: testSingleRegularFileBuffer(t, ""),
+	}))
+
+	attr := new(fuse.Attr)
+	status := file.GetAttr(attr)
+	assertStatusOk(t, status)
+	assert.Equal(t, osFileModeToFuseFileMode(0664), attr.Mode)
+}
+
+func TestAdbFile_Fsync(t *testing.T) {
+	fileBuf := testSingleRegularFileBuffer(t, "hello")
+	file := getAdbFile(NewAdbFile(AdbFileOpenOptions{
+		FileBuffer: fileBuf,
+	}))
+	assert.Equal(t, "hello", fileBuf.Contents())
+
+	// Success.
+	fileBuf.Client.(*delegateDeviceClient).openRead = openReadString("world")
+	status := file.Fsync(0)
+	assertStatusOk(t, status)
+	assert.Equal(t, "world", fileBuf.Contents())
+
+	// Failure.
+	fileBuf.Client.(*delegateDeviceClient).openRead = openReadError(util.Errorf(util.NetworkError, ""))
+	status = file.Fsync(0)
+	assert.Equal(t, fuse.EIO, status)
+	assert.Equal(t, "world", fileBuf.Contents())
+}
+
+func TestAdbFile_ReadWrOnly(t *testing.T) {
+	file := getAdbFile(NewAdbFile(AdbFileOpenOptions{
+		Flags:      O_WRONLY,
+		FileBuffer: testSingleRegularFileBuffer(t, "hello world"),
+	}))
+
+	result, status := file.Read(make([]byte, 5), 0)
+	assert.Equal(t, fuse.EPERM, status)
+	assert.Equal(t, 0, result.Size())
+
+	contents, status := result.Bytes(nil)
+	assert.Equal(t, fuse.EPERM, status)
+	assert.Empty(t, contents)
+}
+
+func TestAdbFile_Read(t *testing.T) {
+	file := getAdbFile(NewAdbFile(AdbFileOpenOptions{
+		FileBuffer: testSingleRegularFileBuffer(t, "hello world"),
+	}))
+
+	result, status := file.Read(make([]byte, 1024), 0)
+	assertStatusOk(t, status)
+
+	contents, status := result.Bytes(nil)
+	assertStatusOk(t, status)
+	assert.Equal(t, "hello world", string(contents))
+}
+
+func getAdbFile(file nodefs.File) *AdbFile {
+	for {
+		if file, ok := file.(*AdbFile); ok {
+			return file
+		}
+		if file == nil {
+			panic("no AdbFile")
+		}
+		file = file.InnerFile()
+	}
+}

--- a/device_client_test.go
+++ b/device_client_test.go
@@ -2,8 +2,11 @@ package adbfs
 
 import (
 	"io"
+	"io/ioutil"
+	"strings"
 
 	"github.com/zach-klippenstein/goadb"
+	"github.com/zach-klippenstein/goadb/util"
 )
 
 type delegateDeviceClient struct {
@@ -27,4 +30,27 @@ func (c *delegateDeviceClient) ListDirEntries(path string, _ *LogEntry) ([]*goad
 
 func (c *delegateDeviceClient) RunCommand(cmd string, args ...string) (string, error) {
 	return c.runCommand(cmd, args)
+}
+
+func statFiles(entries ...*goadb.DirEntry) func(string) (*goadb.DirEntry, error) {
+	return func(path string) (*goadb.DirEntry, error) {
+		for _, entry := range entries {
+			if entry.Name == path {
+				return entry, nil
+			}
+		}
+		return nil, util.Errorf(util.FileNoExistError, "%s", path)
+	}
+}
+
+func openReadString(str string) func(path string) (io.ReadCloser, error) {
+	return func(path string) (io.ReadCloser, error) {
+		return ioutil.NopCloser(strings.NewReader(str)), nil
+	}
+}
+
+func openReadError(err error) func(path string) (io.ReadCloser, error) {
+	return func(path string) (io.ReadCloser, error) {
+		return nil, err
+	}
 }

--- a/file_buffer.go
+++ b/file_buffer.go
@@ -1,0 +1,137 @@
+package adbfs
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"sync"
+	"sync/atomic"
+
+	"github.com/zach-klippenstein/goadb/util"
+)
+
+const DefaultFilePermissions = os.FileMode(0664)
+
+type FileBufferOptions struct {
+	Path   string
+	Client DeviceClient
+
+	// Function called when ref count hits 0.
+	// Note that, because concurrency, the ref count may be incremented again by the time
+	// this function is executed.
+	ZeroRefCountHandler func(*FileBuffer)
+}
+
+/*
+FileBuffer loads, provides read/write access to, and saves a file on the device.
+A single FileBuffer backs all the open files for a given path to provide as consistent a view
+of that file as possible.
+1 or more AdbFiles may point to a single FileBuffer.
+
+Note: On OSX at least, the OS will automatically map multiple open files to a single AdbFile.
+Still, this type is still useful because it separates the file model and logic from the go-fuse-specific
+integration code.
+*/
+type FileBuffer struct {
+	FileBufferOptions
+
+	refCount int32
+
+	// Stores the entire file in memory.
+	buffer []byte
+	lock   sync.Mutex
+}
+
+var _ io.ReaderAt = &FileBuffer{}
+
+// NewFileBuffer returns a File that reads and writes to name on the device.
+// initialFlags are the flags being used to open the file the first time, and are only used to
+// determine if the buffer needs to be read into memory when initializing.
+func NewFileBuffer(initialFlags FileOpenFlags, opts FileBufferOptions, logEntry *LogEntry) (file *FileBuffer, err error) {
+	file = &FileBuffer{
+		FileBufferOptions: opts,
+	}
+	if err := file.initialize(initialFlags, logEntry); err != nil {
+		return nil, err
+	}
+	return file, nil
+}
+
+func (f *FileBuffer) initialize(flags FileOpenFlags, logEntry *LogEntry) (err error) {
+	if !flags.CanRead() || flags.Contains(O_TRUNC) || flags.Contains(O_APPEND) {
+		return os.ErrPermission
+	}
+
+	if _, err = f.Client.Stat(f.Path, logEntry); err != nil {
+		return err
+	}
+
+	// Perform the initial load.
+	f.Sync(logEntry)
+
+	return
+}
+
+func (f *FileBuffer) Contents() string {
+	return string(f.buffer)
+}
+
+// ReadAt implements the io.ReaderAt interface.
+func (f *FileBuffer) ReadAt(buf []byte, off int64) (n int, err error) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	if off > int64(len(f.buffer)) {
+		return 0, io.EOF
+	}
+
+	// Don't use Slice because we don't want to grow the slice.
+	n = copy(buf, f.buffer[off:])
+	if n+int(off) == len(f.buffer) {
+		// This is still a successful read, but there's no more data.
+		err = io.EOF
+	}
+	return n, err
+}
+
+// Sync saves the buffer to the device if dirty, else reloads the buffer from the device.
+func (f *FileBuffer) Sync(logEntry *LogEntry) error {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	return f.loadFromDevice(logEntry)
+}
+
+func (f *FileBuffer) IncRefCount() int {
+	return int(atomic.AddInt32(&f.refCount, 1))
+}
+
+func (f *FileBuffer) DecRefCount() int {
+	newCount := int(atomic.AddInt32(&f.refCount, -1))
+	if newCount < 0 {
+		panic("refcount decremented past 0")
+	}
+	if newCount == 0 && f.ZeroRefCountHandler != nil {
+		f.ZeroRefCountHandler(f)
+	}
+	return newCount
+}
+
+func (f *FileBuffer) RefCount() int {
+	return int(atomic.LoadInt32(&f.refCount))
+}
+
+// read reads the file from the device into the buffer.
+func (f *FileBuffer) loadFromDevice(logEntry *LogEntry) error {
+	stream, err := f.Client.OpenRead(f.Path, logEntry)
+	if err != nil {
+		return util.WrapErrf(err, "error opening file stream on device")
+	}
+	defer stream.Close()
+
+	data, err := ioutil.ReadAll(stream)
+	if err != nil {
+		return util.WrapErrf(err, "error reading data from file (after reading %d bytes)", len(data))
+	}
+	f.buffer = data
+	return nil
+}

--- a/file_buffer_test.go
+++ b/file_buffer_test.go
@@ -1,0 +1,181 @@
+package adbfs
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zach-klippenstein/goadb"
+	"github.com/zach-klippenstein/goadb/util"
+)
+
+func TestNewFileBuffer_RdonlyExistSuccess(t *testing.T) {
+	for _, config := range []struct {
+		flags            FileOpenFlags
+		expectedContents string
+	}{
+		{O_RDONLY, "hello"},
+		{O_RDWR, "hello"},
+		{O_RDWR | O_CREATE, "hello"},
+	} {
+		file := testSingleRegularFileBuffer(t, config.expectedContents)
+
+		assert.NotNil(t, file)
+		assert.Equal(t, config.expectedContents, file.Contents(), "%v", config)
+	}
+}
+
+func TestNewFileBuffer_RdonlyNoExistFailure(t *testing.T) {
+	file, err := NewFileBuffer(O_RDONLY, FileBufferOptions{
+		Path: "/file",
+		Client: &delegateDeviceClient{
+			stat: statFiles(),
+		},
+	}, &LogEntry{})
+	assert.True(t, util.HasErrCode(err, util.FileNoExistError))
+	assert.Nil(t, file)
+}
+
+func TestNewFileBuffer_OpenWithoutReadFailure(t *testing.T) {
+	for _, flags := range []FileOpenFlags{O_TRUNC, O_APPEND} {
+		_, err := NewFileBuffer(flags, FileBufferOptions{
+			Path:   "/file",
+			Client: &delegateDeviceClient{},
+		}, &LogEntry{})
+
+		assert.Equal(t, os.ErrPermission, err)
+	}
+}
+
+func TestFileBufferSync(t *testing.T) {
+	dev := &delegateDeviceClient{
+		stat: statFiles(&goadb.DirEntry{
+			Name: "/file",
+			Mode: 0664,
+		}),
+		openRead: openReadString("hello"),
+	}
+	file := newTestFileBuffer(t, O_RDONLY, FileBufferOptions{
+		Path:   "/file",
+		Client: dev,
+	})
+	assert.Equal(t, "hello", file.Contents())
+
+	// Success.
+	dev.openRead = openReadString("world")
+	err := file.Sync(&LogEntry{})
+	assert.NoError(t, err)
+	assert.Equal(t, "world", file.Contents())
+
+	// Failure.
+	dev.openRead = openReadError(util.Errorf(util.NetworkError, "fail"))
+	err = file.Sync(&LogEntry{})
+	assert.Equal(t, `NetworkError: error opening file stream on device
+caused by NetworkError: fail`, util.ErrorWithCauseChain(err))
+	assert.Equal(t, "world", file.Contents())
+}
+
+func TestFileBufferReadAt(t *testing.T) {
+	file := testSingleRegularFileBuffer(t, "hello world")
+
+	var buf []byte
+	var n int
+	var err error
+
+	// Read empty buffer.
+	buf = make([]byte, 0)
+	n, err = file.ReadAt(buf, 0)
+	assert.Equal(t, 0, n)
+	assert.NoError(t, err)
+	assert.Equal(t, "", string(buf))
+
+	// Read less than available.
+	buf = make([]byte, 5)
+	n, err = file.ReadAt(buf, 0)
+	assert.Equal(t, len(buf), n)
+	assert.NoError(t, err)
+	assert.Equal(t, "hello", string(buf))
+
+	// Read exactly available.
+	buf = make([]byte, len("hello world"))
+	n, err = file.ReadAt(buf, 0)
+	assert.Equal(t, len(buf), n)
+	assert.Equal(t, io.EOF, err)
+	assert.Equal(t, "hello world", string(buf))
+
+	// Read from middle of stream.
+	buf = make([]byte, 5)
+	n, err = file.ReadAt(buf, 6)
+	assert.Equal(t, len(buf), n)
+	assert.Equal(t, io.EOF, err)
+	assert.Equal(t, "world", string(buf))
+
+	// Try reading more than available.
+	buf = make([]byte, 1024)
+	n, err = file.ReadAt(buf, 0)
+	assert.Equal(t, len("hello world"), n)
+	assert.Equal(t, io.EOF, err)
+	assert.Equal(t, "hello world", string(buf[:n]))
+
+	// Try reading after last data.
+	buf = make([]byte, 5)
+	n, err = file.ReadAt(buf, 1024)
+	assert.Equal(t, 0, n)
+	assert.Equal(t, io.EOF, err)
+	assert.Equal(t, "", string(buf[:n]))
+}
+
+func TestFileBuffer_RefCount(t *testing.T) {
+	zeroRefCountHandlerCalled := false
+
+	file := newTestFileBuffer(t, O_RDONLY, FileBufferOptions{
+		Path: "/",
+		ZeroRefCountHandler: func(f *FileBuffer) {
+			zeroRefCountHandlerCalled = true
+		},
+		Client: &delegateDeviceClient{
+			stat: statFiles(&goadb.DirEntry{
+				Name: "/",
+			}),
+			openRead: openReadString(""),
+		},
+	})
+	assert.Equal(t, 0, file.RefCount())
+	assert.False(t, zeroRefCountHandlerCalled)
+
+	assert.Equal(t, 1, file.IncRefCount())
+	assert.Equal(t, 1, file.RefCount())
+
+	assert.Equal(t, 0, file.DecRefCount())
+	assert.Equal(t, 0, file.RefCount())
+	assert.True(t, zeroRefCountHandlerCalled)
+
+	func() {
+		defer func() {
+			p := recover()
+			assert.NotNil(t, p)
+			assert.Equal(t, "refcount decremented past 0", p)
+		}()
+		file.DecRefCount()
+	}()
+}
+
+func newTestFileBuffer(t *testing.T, flags FileOpenFlags, opts FileBufferOptions) *FileBuffer {
+	f, err := NewFileBuffer(flags, opts, &LogEntry{})
+	assert.NoError(t, err)
+	return f
+}
+
+func testSingleRegularFileBuffer(t *testing.T, contents string) *FileBuffer {
+	return newTestFileBuffer(t, O_RDONLY, FileBufferOptions{
+		Path: "/",
+		Client: &delegateDeviceClient{
+			stat: statFiles(&goadb.DirEntry{
+				Name: "/",
+				Mode: 0664,
+			}),
+			openRead: openReadString(contents),
+		},
+	})
+}

--- a/file_open_flags.go
+++ b/file_open_flags.go
@@ -1,0 +1,38 @@
+package adbfs
+
+import (
+	"os"
+
+	"github.com/hanwen/go-fuse/fuse"
+)
+
+const (
+	O_RDONLY = FileOpenFlags(os.O_RDONLY)
+	O_WRONLY = FileOpenFlags(os.O_WRONLY)
+	O_RDWR   = FileOpenFlags(os.O_RDWR)
+	O_APPEND = FileOpenFlags(os.O_APPEND)
+	O_CREATE = FileOpenFlags(os.O_CREATE)
+	O_EXCL   = FileOpenFlags(os.O_EXCL)
+	O_SYNC   = FileOpenFlags(os.O_SYNC)
+	O_TRUNC  = FileOpenFlags(os.O_TRUNC)
+)
+
+// Helper methods around the flags passed to the Open call.
+type FileOpenFlags uint32
+
+func (f FileOpenFlags) String() string {
+	return fuse.FlagString(fuse.OpenFlagNames, int64(f), "")
+}
+
+func (f FileOpenFlags) GoString() string {
+	return f.String()
+}
+
+func (f FileOpenFlags) CanRead() bool {
+	// O_RDONLY is just 0, so we can't do Contains(O_RDONLY).
+	return !f.Contains(O_WRONLY)
+}
+
+func (f FileOpenFlags) Contains(bits FileOpenFlags) bool {
+	return (f & bits) == bits
+}

--- a/file_open_flags_test.go
+++ b/file_open_flags_test.go
@@ -1,0 +1,13 @@
+package adbfs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFuseOpenFlagsCanRead(t *testing.T) {
+	assert.True(t, O_RDONLY.CanRead())
+	assert.True(t, O_RDWR.CanRead())
+	assert.False(t, O_WRONLY.CanRead())
+}

--- a/open_files.go
+++ b/open_files.go
@@ -1,0 +1,65 @@
+package adbfs
+
+import (
+	"sync"
+
+	"github.com/zach-klippenstein/adbfs/internal/cli"
+)
+
+type OpenFilesOptions struct {
+	DeviceSerial  string
+	ClientFactory DeviceClientFactory
+}
+
+// OpenFiles tracks and manages the set of all open files in a filesystem.
+type OpenFiles struct {
+	OpenFilesOptions
+
+	lock          sync.Mutex
+	buffersByPath map[string]*FileBuffer
+}
+
+func NewOpenFiles(opts OpenFilesOptions) *OpenFiles {
+	return &OpenFiles{
+		OpenFilesOptions: opts,
+		buffersByPath:    make(map[string]*FileBuffer),
+	}
+}
+
+func (f *OpenFiles) GetOrLoad(path string, openFlags FileOpenFlags, logEntry *LogEntry) (file *FileBuffer, err error) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	if file = f.buffersByPath[path]; file == nil {
+		file, err = NewFileBuffer(openFlags, FileBufferOptions{
+			Path:                path,
+			Client:              f.OpenFilesOptions.ClientFactory(),
+			ZeroRefCountHandler: f.release,
+		}, logEntry)
+		if err != nil {
+			return nil, err
+		}
+		f.buffersByPath[path] = file
+	}
+
+	// The refcount will be decremented when the AdbFile is released.
+	refCount := file.IncRefCount()
+	cli.Log.Debugf("OpenFiles: refcount is now %d for %s", refCount, path)
+
+	return file, nil
+}
+
+func (f *OpenFiles) release(file *FileBuffer) {
+	// Acquire the lock first, so that a concurrent call to GetOrLoad won't be able to increment
+	// the refcount before we remove it from the map.
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	// However, the GetOrLoad may already have beat us to the punch.
+	if file.RefCount() != 0 {
+		return
+	}
+
+	cli.Log.Debugf("OpenFiles: releasing FileBuffer for %s", file.Path)
+	delete(f.buffersByPath, file.Path)
+}

--- a/open_files_test.go
+++ b/open_files_test.go
@@ -1,0 +1,66 @@
+package adbfs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zach-klippenstein/goadb"
+)
+
+func TestOpenFiles_GetOrLoadSameFileSeparate(t *testing.T) {
+	dev := &delegateDeviceClient{
+		stat: statFiles(&goadb.DirEntry{
+			Name: "/",
+		}),
+		openRead: openReadString("hello"),
+	}
+	o := NewOpenFiles(OpenFilesOptions{
+		DeviceSerial:  "abc",
+		ClientFactory: func() DeviceClient { return dev },
+	})
+
+	f1, err := o.GetOrLoad("/", O_RDONLY, &LogEntry{})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, f1.RefCount())
+
+	f1.DecRefCount()
+
+	f2, err := o.GetOrLoad("/", O_RDONLY, &LogEntry{})
+	assert.NoError(t, err)
+	assert.NotEqual(t, f1, f2)
+	assert.Equal(t, 1, f2.RefCount())
+	assert.Equal(t, 0, f1.RefCount())
+}
+
+func TestOpenFiles_GetOrLoadSameFileShared(t *testing.T) {
+	dev := &delegateDeviceClient{
+		stat: statFiles(&goadb.DirEntry{
+			Name: "/",
+		}),
+		openRead: openReadString("hello"),
+	}
+	o := NewOpenFiles(OpenFilesOptions{
+		DeviceSerial:  "abc",
+		ClientFactory: func() DeviceClient { return dev },
+	})
+
+	f1, err := o.GetOrLoad("/", O_RDONLY, &LogEntry{})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, f1.RefCount())
+
+	f2, err := o.GetOrLoad("/", O_RDONLY, &LogEntry{})
+	assert.NoError(t, err)
+	assert.Equal(t, f1, f2)
+	assert.Equal(t, 2, f2.RefCount())
+	assert.Equal(t, 2, f1.RefCount())
+
+	f1.DecRefCount()
+	assert.Equal(t, 1, f2.RefCount())
+	assert.Equal(t, 1, f1.RefCount())
+
+	f3, err := o.GetOrLoad("/", O_RDONLY, &LogEntry{})
+	assert.NoError(t, err)
+	assert.Equal(t, f2, f3)
+	assert.Equal(t, 2, f3.RefCount())
+	assert.Equal(t, 2, f2.RefCount())
+}

--- a/read_result_error.go
+++ b/read_result_error.go
@@ -1,0 +1,18 @@
+package adbfs
+
+import "github.com/hanwen/go-fuse/fuse"
+
+type readResultError fuse.Status
+
+var _ fuse.ReadResult = readResultError(fuse.ENOSYS)
+
+func (e readResultError) Bytes(buf []byte) ([]byte, fuse.Status) {
+	return nil, fuse.Status(e)
+}
+
+func (e readResultError) Size() int {
+	return 0
+}
+
+func (e readResultError) Done() {
+}


### PR DESCRIPTION
The read logic is still essentially the same, except that the underlying buffer
is shared by all open files with the same path.