### PR TITLE
Implemented (experimental) file writing.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -35,7 +35,7 @@
 		},
 		{
 			"ImportPath": "github.com/zach-klippenstein/goadb",
-			"Rev": "b966d11cda2282932f0f35bfa88698a9d8398e69"
+			"Rev": "aea57fe58fcf1ccd040aeeca72babc658247d630"
 		},
 		{
 			"ImportPath": "golang.org/x/net/context",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ A FUSE filesystem that uses [goadb](https://github.com/zach-klippenstein/goadb) 
 
 ## Features
 
-* **Read-only**, non-root access to Android devices' filesystems through adb. Write access is planned for v1.0.
+* Read access to Android device filesystems through adb, *without root*. Of course, this is limited to files that are accessible to whatever user `adb shell` runs the shell as on the device.
+* Experimental write support (run with `--no-readonly`).
 * Automounter daemon that detects when devices are connected and mounts them under a configurable directory.
 * Communicates directly with adb server using goadb instead of delegating to the adb client command like most adb-based filesystems.
 

--- a/adb_file_test.go
+++ b/adb_file_test.go
@@ -1,17 +1,20 @@
 package adbfs
 
 import (
+	"bytes"
 	"testing"
+	"time"
 
 	"github.com/hanwen/go-fuse/fuse"
 	"github.com/hanwen/go-fuse/fuse/nodefs"
 	"github.com/stretchr/testify/assert"
+	. "github.com/zach-klippenstein/adbfs/internal/util"
 	"github.com/zach-klippenstein/goadb/util"
 )
 
 func TestAdbFile_InnerFile(t *testing.T) {
 	file := getAdbFile(NewAdbFile(AdbFileOpenOptions{
-		FileBuffer: testSingleRegularFileBuffer(t, ""),
+		FileBuffer: testSingleRegularRoFileBuffer(t, ""),
 	}))
 
 	assert.NotNil(t, file.InnerFile())
@@ -19,7 +22,7 @@ func TestAdbFile_InnerFile(t *testing.T) {
 }
 
 func TestAdbFile_Release(t *testing.T) {
-	fileBuf := testSingleRegularFileBuffer(t, "")
+	fileBuf := testSingleRegularRoFileBuffer(t, "")
 	fileBuf.IncRefCount()
 	file := getAdbFile(NewAdbFile(AdbFileOpenOptions{
 		FileBuffer: fileBuf,
@@ -31,7 +34,7 @@ func TestAdbFile_Release(t *testing.T) {
 
 func TestAdbFile_GetAttr(t *testing.T) {
 	file := getAdbFile(NewAdbFile(AdbFileOpenOptions{
-		FileBuffer: testSingleRegularFileBuffer(t, ""),
+		FileBuffer: testSingleRegularRoFileBuffer(t, ""),
 	}))
 
 	attr := new(fuse.Attr)
@@ -41,7 +44,7 @@ func TestAdbFile_GetAttr(t *testing.T) {
 }
 
 func TestAdbFile_Fsync(t *testing.T) {
-	fileBuf := testSingleRegularFileBuffer(t, "hello")
+	fileBuf := testSingleRegularRoFileBuffer(t, "hello")
 	file := getAdbFile(NewAdbFile(AdbFileOpenOptions{
 		FileBuffer: fileBuf,
 	}))
@@ -63,7 +66,7 @@ func TestAdbFile_Fsync(t *testing.T) {
 func TestAdbFile_ReadWrOnly(t *testing.T) {
 	file := getAdbFile(NewAdbFile(AdbFileOpenOptions{
 		Flags:      O_WRONLY,
-		FileBuffer: testSingleRegularFileBuffer(t, "hello world"),
+		FileBuffer: testSingleRegularRoFileBuffer(t, "hello world"),
 	}))
 
 	result, status := file.Read(make([]byte, 5), 0)
@@ -77,7 +80,7 @@ func TestAdbFile_ReadWrOnly(t *testing.T) {
 
 func TestAdbFile_Read(t *testing.T) {
 	file := getAdbFile(NewAdbFile(AdbFileOpenOptions{
-		FileBuffer: testSingleRegularFileBuffer(t, "hello world"),
+		FileBuffer: testSingleRegularRoFileBuffer(t, "hello world"),
 	}))
 
 	result, status := file.Read(make([]byte, 1024), 0)
@@ -86,6 +89,89 @@ func TestAdbFile_Read(t *testing.T) {
 	contents, status := result.Bytes(nil)
 	assertStatusOk(t, status)
 	assert.Equal(t, "hello world", string(contents))
+}
+
+func TestAdbFile_TruncateReadOnly(t *testing.T) {
+	file := getAdbFile(NewAdbFile(AdbFileOpenOptions{
+		FileBuffer: testSingleRegularRoFileBuffer(t, "hello world"),
+		Flags:      O_RDONLY,
+	}))
+
+	status := file.Truncate(0)
+	assert.Equal(t, fuse.EPERM, status)
+}
+
+func TestAdbFile_TruncateSuccess(t *testing.T) {
+	TestClock.Reset()
+	fbuf, dev := testSingleRegularRdwrFileBuffer(t, "hello world")
+	file := getAdbFile(NewAdbFile(AdbFileOpenOptions{
+		FileBuffer: fbuf,
+		Flags:      O_RDWR,
+	}))
+
+	status := file.Truncate(0)
+	assertStatusOk(t, status)
+	assert.EqualValues(t, 0, file.FileBuffer.Size())
+	assert.Equal(t, "", dev.String())
+
+	status = file.Truncate(10)
+	assertStatusOk(t, status)
+	assert.EqualValues(t, 10, file.FileBuffer.Size())
+	assert.Equal(t, bytes.Repeat([]byte{0}, 10), dev.Bytes())
+}
+
+func TestAdbFile_WriteSuccess(t *testing.T) {
+	TestClock.Reset()
+	fbuf, dev := testSingleRegularRdwrFileBuffer(t, "")
+	fbuf.DirtyTimeout = 5 * time.Second
+	file := getAdbFile(NewAdbFile(AdbFileOpenOptions{
+		FileBuffer: fbuf,
+		Flags:      O_RDWR,
+	}))
+
+	n, status := file.Write([]byte("hello world"), 0)
+	assertStatusOk(t, status)
+	assert.EqualValues(t, 11, n)
+	assert.EqualValues(t, 11, file.FileBuffer.Size())
+	// Write shouldn't flush unless too dirty.
+	assert.Empty(t, dev.String())
+
+	n, status = file.Write([]byte("goodbye"), 6)
+	assertStatusOk(t, status)
+	assert.EqualValues(t, 7, n)
+	assert.EqualValues(t, 13, file.FileBuffer.Size())
+	assert.Empty(t, dev.String())
+
+	// Allow time to pass to trigger a flush.
+	TestClock.Advance(6 * time.Second)
+	n, status = file.Write([]byte("world"), 0)
+	assertStatusOk(t, status)
+	assert.Equal(t, "world goodbye", dev.String())
+}
+
+func TestAdbFile_WriteReadOnly(t *testing.T) {
+	fbuf, dev := testSingleRegularRdwrFileBuffer(t, "")
+	file := getAdbFile(NewAdbFile(AdbFileOpenOptions{
+		FileBuffer: fbuf,
+		Flags:      O_RDONLY,
+	}))
+
+	n, status := file.Write([]byte("hello world"), 0)
+	assert.Equal(t, fuse.EPERM, status)
+	assert.EqualValues(t, 0, n)
+	assert.EqualValues(t, 0, file.FileBuffer.Size())
+	assert.Empty(t, dev.String())
+}
+
+func TestAdbFile_FlushReadOnly(t *testing.T) {
+	fbuf, _ := testSingleRegularRdwrFileBuffer(t, "")
+	file := getAdbFile(NewAdbFile(AdbFileOpenOptions{
+		FileBuffer: fbuf,
+		Flags:      O_RDONLY,
+	}))
+
+	status := file.Flush()
+	assertStatusOk(t, status)
 }
 
 func getAdbFile(file nodefs.File) *AdbFile {

--- a/cmd/adbfs-automount/main.go
+++ b/cmd/adbfs-automount/main.go
@@ -32,6 +32,12 @@ func main() {
 	config.InitializePaths()
 	eventLog.Infof("using mount root %s", config.MountRoot)
 
+	if config.ReadOnly {
+		eventLog.Infof("mounting as read-only filesystem")
+	} else {
+		eventLog.Infof("mounting as writable filesystem")
+	}
+
 	deviceWatcher := goadb.NewDeviceWatcher(config.ClientConfig())
 	defer deviceWatcher.Shutdown()
 

--- a/cmd/adbfs/main.go
+++ b/cmd/adbfs/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hanwen/go-fuse/fuse/pathfs"
 	fs "github.com/zach-klippenstein/adbfs"
 	"github.com/zach-klippenstein/adbfs/internal/cli"
+	. "github.com/zach-klippenstein/adbfs/internal/util"
 	"github.com/zach-klippenstein/goadb"
 )
 
@@ -31,10 +32,10 @@ var (
 
 	server *fuse.Server
 
-	mounted fs.AtomicBool
+	mounted AtomicBool
 
 	// Prevents trying to unmount the server multiple times.
-	unmounted fs.AtomicBool
+	unmounted AtomicBool
 )
 
 func init() {
@@ -114,6 +115,7 @@ func initializeFileSystem(clientConfig goadb.ClientConfig, mountpoint string, ca
 		ClientFactory:      clientFactory,
 		ConnectionPoolSize: config.ConnectionPoolSize,
 		DeviceRoot:         config.DeviceRoot,
+		ReadOnly:           config.ReadOnly,
 	})
 	if err != nil {
 		cli.Log.Fatal(err)

--- a/device_client.go
+++ b/device_client.go
@@ -2,6 +2,8 @@ package adbfs
 
 import (
 	"io"
+	"os"
+	"time"
 
 	"github.com/zach-klippenstein/goadb"
 	"github.com/zach-klippenstein/goadb/util"
@@ -10,6 +12,7 @@ import (
 // DeviceClient wraps goadb.DeviceClient for testing.
 type DeviceClient interface {
 	OpenRead(path string, log *LogEntry) (io.ReadCloser, error)
+	OpenWrite(path string, perms os.FileMode, mtime time.Time, log *LogEntry) (io.WriteCloser, error)
 	Stat(path string, log *LogEntry) (*goadb.DirEntry, error)
 	ListDirEntries(path string, log *LogEntry) ([]*goadb.DirEntry, error)
 
@@ -49,6 +52,10 @@ func (c goadbDeviceClient) OpenRead(path string, _ *LogEntry) (io.ReadCloser, er
 		return nil, c.handleDeviceNotFound(err)
 	}
 	return r, err
+}
+
+func (c goadbDeviceClient) OpenWrite(path string, mode os.FileMode, mtime time.Time, _ *LogEntry) (io.WriteCloser, error) {
+	return c.DeviceClient.OpenWrite(path, mode, mtime)
 }
 
 func (c goadbDeviceClient) Stat(path string, _ *LogEntry) (*goadb.DirEntry, error) {

--- a/device_client_test.go
+++ b/device_client_test.go
@@ -3,7 +3,11 @@ package adbfs
 import (
 	"io"
 	"io/ioutil"
+	"os"
 	"strings"
+	"time"
+
+	"bytes"
 
 	"github.com/zach-klippenstein/goadb"
 	"github.com/zach-klippenstein/goadb/util"
@@ -11,6 +15,7 @@ import (
 
 type delegateDeviceClient struct {
 	openRead       func(path string) (io.ReadCloser, error)
+	openWrite      func(path string, mode os.FileMode, mtime time.Time) (io.WriteCloser, error)
 	stat           func(path string) (*goadb.DirEntry, error)
 	listDirEntries func(path string) ([]*goadb.DirEntry, error)
 	runCommand     func(cmd string, args []string) (string, error)
@@ -18,6 +23,10 @@ type delegateDeviceClient struct {
 
 func (c *delegateDeviceClient) OpenRead(path string, _ *LogEntry) (io.ReadCloser, error) {
 	return c.openRead(path)
+}
+
+func (c *delegateDeviceClient) OpenWrite(path string, mode os.FileMode, mtime time.Time, _ *LogEntry) (io.WriteCloser, error) {
+	return c.openWrite(path, mode, mtime)
 }
 
 func (c *delegateDeviceClient) Stat(path string, _ *LogEntry) (*goadb.DirEntry, error) {
@@ -53,4 +62,46 @@ func openReadError(err error) func(path string) (io.ReadCloser, error) {
 	return func(path string) (io.ReadCloser, error) {
 		return nil, err
 	}
+}
+
+func openWriteNoop() func(path string, mode os.FileMode, mtime time.Time) (io.WriteCloser, error) {
+	return openWriteTo(nil)
+}
+
+func openWriteTo(w *bytes.Buffer) func(path string, mode os.FileMode, mtime time.Time) (io.WriteCloser, error) {
+	return func(path string, mode os.FileMode, mtime time.Time) (io.WriteCloser, error) {
+		// Simulate how a goadb.OpenRead call works.
+		if w != nil {
+			w.Reset()
+		}
+
+		return noopWriteCloser{
+			w:     w,
+			Mode:  mode,
+			Mtime: mtime,
+		}, nil
+	}
+}
+
+func openWriteError(err error) func(path string, mode os.FileMode, mtime time.Time) (io.WriteCloser, error) {
+	return func(path string, mode os.FileMode, mtime time.Time) (io.WriteCloser, error) {
+		return nil, err
+	}
+}
+
+type noopWriteCloser struct {
+	w     io.Writer
+	Mode  os.FileMode
+	Mtime time.Time
+}
+
+func (w noopWriteCloser) Write(data []byte) (int, error) {
+	if w.w != nil {
+		return w.w.Write(data)
+	}
+	return 0, nil
+}
+
+func (noopWriteCloser) Close() error {
+	return nil
 }

--- a/dir_entry_cache.go
+++ b/dir_entry_cache.go
@@ -16,6 +16,8 @@ type DirEntryLoader func(path string) (*CachedDirEntries, error)
 type DirEntryCache interface {
 	GetOrLoad(path string, loader DirEntryLoader) (entries *CachedDirEntries, err error, hit bool)
 	Get(path string) (entries *CachedDirEntries, found bool)
+	// Removes the entry for path from the cache without blocking on other cache operations.
+	RemoveEventually(path string)
 }
 
 type realDirEntryCache struct {
@@ -51,4 +53,8 @@ func (c *realDirEntryCache) Get(path string) (*CachedDirEntries, bool) {
 	}
 	c.eventLog.Errorf("Get(%s) = miss", path)
 	return nil, false
+}
+
+func (c *realDirEntryCache) RemoveEventually(path string) {
+	go c.cache.Delete(path)
 }

--- a/dir_entry_cache_test.go
+++ b/dir_entry_cache_test.go
@@ -10,8 +10,9 @@ import (
 )
 
 type delegateDirEntryCache struct {
-	DoGetOrLoad func(path string, loader DirEntryLoader) (entries *CachedDirEntries, err error, hit bool)
-	DoGet       func(path string) (entries *CachedDirEntries, found bool)
+	DoGetOrLoad        func(path string, loader DirEntryLoader) (entries *CachedDirEntries, err error, hit bool)
+	DoGet              func(path string) (entries *CachedDirEntries, found bool)
+	DoRemoveEventually func(path string)
 }
 
 func (c *delegateDirEntryCache) GetOrLoad(path string, loader DirEntryLoader) (entries *CachedDirEntries, err error, hit bool) {
@@ -20,6 +21,10 @@ func (c *delegateDirEntryCache) GetOrLoad(path string, loader DirEntryLoader) (e
 
 func (c *delegateDirEntryCache) Get(path string) (entries *CachedDirEntries, found bool) {
 	return c.DoGet(path)
+}
+
+func (c *delegateDirEntryCache) RemoveEventually(path string) {
+	c.DoRemoveEventually(path)
 }
 
 func TestDirEntryCacheLoadSuccess(t *testing.T) {

--- a/errors.go
+++ b/errors.go
@@ -42,7 +42,8 @@ func toErrnoLog(err error, logEntry *LogEntry) (status syscall.Errno) {
 // toErrno converts a known error to an Errno, or EIO if the error is not known.
 func toErrno(err error) syscall.Errno {
 	switch {
-	case err == nil:
+	case err == nil || err == OK:
+		// Passing OK can be more readable than passing nil.
 		return OK
 	case err == ErrLinkTooDeep:
 		return syscall.ELOOP

--- a/file_buffer.go
+++ b/file_buffer.go
@@ -2,19 +2,28 @@ package adbfs
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"sync"
 	"sync/atomic"
+	"time"
 
+	. "github.com/zach-klippenstein/adbfs/internal/util"
+	"github.com/zach-klippenstein/goadb"
 	"github.com/zach-klippenstein/goadb/util"
 )
 
 const DefaultFilePermissions = os.FileMode(0664)
 
 type FileBufferOptions struct {
-	Path   string
-	Client DeviceClient
+	Path         string
+	Client       DeviceClient
+	Clock        Clock
+	DirtyTimeout time.Duration
+
+	// The permissions to set on the file when flushing.
+	// If this is DontSetPerms, the file's existing permissions will be used.
+	// Set from the existing file if it exists, or to the desired new permissions if new.
+	Perms os.FileMode
 
 	// Function called when ref count hits 0.
 	// Note that, because concurrency, the ref count may be incremented again by the time
@@ -36,13 +45,17 @@ type FileBuffer struct {
 	FileBufferOptions
 
 	refCount int32
+	lock     sync.Mutex
 
 	// Stores the entire file in memory.
-	buffer []byte
-	lock   sync.Mutex
+	buffer GrowableByteSlice
+	dirty  *DirtyTimestamp
 }
 
-var _ io.ReaderAt = &FileBuffer{}
+var (
+	_ io.ReaderAt = &FileBuffer{}
+	_ io.WriterAt = &FileBuffer{}
+)
 
 // NewFileBuffer returns a File that reads and writes to name on the device.
 // initialFlags are the flags being used to open the file the first time, and are only used to
@@ -50,6 +63,7 @@ var _ io.ReaderAt = &FileBuffer{}
 func NewFileBuffer(initialFlags FileOpenFlags, opts FileBufferOptions, logEntry *LogEntry) (file *FileBuffer, err error) {
 	file = &FileBuffer{
 		FileBufferOptions: opts,
+		dirty:             NewDirtyTimestamp(opts.Clock),
 	}
 	if err := file.initialize(initialFlags, logEntry); err != nil {
 		return nil, err
@@ -58,47 +72,130 @@ func NewFileBuffer(initialFlags FileOpenFlags, opts FileBufferOptions, logEntry 
 }
 
 func (f *FileBuffer) initialize(flags FileOpenFlags, logEntry *LogEntry) (err error) {
-	if !flags.CanRead() || flags.Contains(O_TRUNC) || flags.Contains(O_APPEND) {
+	createNewFile := false
+
+	flagRequiresWrite := flags.Contains(O_CREATE | O_TRUNC | O_APPEND)
+	if flagRequiresWrite && !flags.CanWrite() {
 		return ErrNotPermitted
 	}
 
-	if _, err = f.Client.Stat(f.Path, logEntry); err != nil {
+	currentPerms, err := f.getFilePermissions(logEntry)
+	if util.HasErrCode(err, util.FileNoExistError) {
+		// The file doesn't exist.
+		if !flags.Contains(O_CREATE) {
+			// If the file doesn't exist and we can't create, we can't do anything.
+			return err
+		}
+
+		createNewFile = true
+		currentPerms = DefaultFilePermissions
+		err = nil
+	} else if err != nil {
 		return err
 	}
 
-	// Perform the initial load.
+	if f.Perms == DontSetPerms {
+		// Open won't set perms and we want to use the existing ones from the file if it exists.
+		// If it doesn't, use the default ones from the AdbFileSystem.
+		// Create should always set this to non-zero.
+		f.Perms = currentPerms
+	}
+
+	// Now either the file exists or it doesn't and we can create it.
+
+	if createNewFile || flags.Contains(O_TRUNC) {
+		// We don't care what was in the file (if it exists), leave the buffer empty.
+		//
+		// Not sure about other OSes, but OSX Finder will do a GetAttr on the file immediately after
+		// the Create syscall (before flushing), and if it fails, will give up.
+		f.dirty.Set()
+	}
+
+	// Perform the initial load or save.
 	f.Sync(logEntry)
 
 	return
 }
 
+func (f *FileBuffer) getFilePermissions(logEntry *LogEntry) (os.FileMode, error) {
+	entry, err := f.Client.Stat(f.Path, logEntry)
+	if err != nil {
+		return 0, util.WrapErrf(err, "error reading file permissions")
+	}
+	return entry.Mode.Perm(), nil
+}
+
 func (f *FileBuffer) Contents() string {
-	return string(f.buffer)
+	return f.buffer.String()
 }
 
 // ReadAt implements the io.ReaderAt interface.
 func (f *FileBuffer) ReadAt(buf []byte, off int64) (n int, err error) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
+	return f.buffer.ReadAt(buf, off)
+}
 
-	if off > int64(len(f.buffer)) {
-		return 0, io.EOF
-	}
-
-	// Don't use Slice because we don't want to grow the slice.
-	n = copy(buf, f.buffer[off:])
-	if n+int(off) == len(f.buffer) {
-		// This is still a successful read, but there's no more data.
-		err = io.EOF
-	}
-	return n, err
+func (f *FileBuffer) WriteAt(data []byte, off int64) (int, error) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	// FileBuffer.WriteAt will never fail, so we can set the dirty flag before writing.
+	f.dirty.Set()
+	return f.buffer.WriteAt(data, off)
 }
 
 // Sync saves the buffer to the device if dirty, else reloads the buffer from the device.
+// Like Flush, but reloads the buffer if not dirty.
 func (f *FileBuffer) Sync(logEntry *LogEntry) error {
 	f.lock.Lock()
 	defer f.lock.Unlock()
-	return f.loadFromDevice(logEntry)
+
+	if f.dirty.IsSet() {
+		return f.saveToDevice(logEntry)
+	} else {
+		return f.loadFromDevice(logEntry)
+	}
+}
+
+// Flush saves the buffer to the device if dirty, else does nothing.
+// Like Sync, but without the read.
+func (f *FileBuffer) Flush(logEntry *LogEntry) error {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	if f.dirty.IsSet() {
+		return f.saveToDevice(logEntry)
+	}
+	return nil
+}
+
+// SyncIfTooDirty performs a sync if the buffer has been dirty for longer than the timeout specified
+// in FileBufferOptions.
+func (f *FileBuffer) SyncIfTooDirty(logEntry *LogEntry) error {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	if f.dirty.HasBeenDirtyFor(f.FileBufferOptions.DirtyTimeout) {
+		return f.saveToDevice(logEntry)
+	}
+	return nil
+}
+
+func (f *FileBuffer) SetSize(size int64) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	f.dirty.Set()
+	f.buffer.Resize(size)
+}
+
+func (f *FileBuffer) Size() int64 {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	return f.buffer.Len()
+}
+
+func (f *FileBuffer) IsDirty() bool {
+	return f.dirty.IsSet()
 }
 
 func (f *FileBuffer) IncRefCount() int {
@@ -128,10 +225,35 @@ func (f *FileBuffer) loadFromDevice(logEntry *LogEntry) error {
 	}
 	defer stream.Close()
 
-	data, err := ioutil.ReadAll(stream)
+	n, err := f.buffer.ReadFrom(stream)
 	if err != nil {
-		return util.WrapErrf(err, "error reading data from file (after reading %d bytes)", len(data))
+		return util.WrapErrf(err, "error reading data from file (after reading %d bytes)", n)
 	}
-	f.buffer = data
+	return nil
+}
+
+func (f *FileBuffer) saveToDevice(logEntry *LogEntry) error {
+	writer, err := f.Client.OpenWrite(f.Path, f.Perms, goadb.MtimeOfClose, logEntry)
+	if err != nil {
+		return util.WrapErrf(err, "error opening file stream on device")
+	}
+	// Make sure we close the writer if we return early, but we still want to check
+	// for errors in the happy case.
+	defer writer.Close()
+
+	// TODO Optimize by using a buffer that is wire.SyncMaxChunkSize.
+	n, err := f.buffer.WriteTo(writer)
+	if err != nil {
+		return util.WrapErrf(err, "writing data to file: len(buffer)=%d, n=%d", f.buffer.Len(), n)
+	}
+
+	if err := writer.Close(); err != nil {
+		return util.WrapErrf(err, "closing file stream")
+	}
+
+	// If there were any errors, the file may not have been written on device at all, so we're still
+	// dirty.
+	f.dirty.Clear()
+
 	return nil
 }

--- a/file_buffer_test.go
+++ b/file_buffer_test.go
@@ -1,10 +1,15 @@
 package adbfs
 
 import (
+	"bytes"
 	"io"
+	"io/ioutil"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	. "github.com/zach-klippenstein/adbfs/internal/util"
 	"github.com/zach-klippenstein/goadb"
 	"github.com/zach-klippenstein/goadb/util"
 )
@@ -17,9 +22,28 @@ func TestNewFileBuffer_RdonlyExistSuccess(t *testing.T) {
 		{O_RDONLY, "hello"},
 		{O_RDWR, "hello"},
 		{O_RDWR | O_CREATE, "hello"},
+		{O_RDWR | O_TRUNC, ""},
+		{O_RDWR | O_APPEND, "hello"},
+		{O_WRONLY, "hello"},
+		{O_WRONLY | O_CREATE, "hello"},
+		{O_WRONLY | O_TRUNC, ""},
+		{O_WRONLY | O_APPEND, "hello"},
 	} {
-		file := testSingleRegularFileBuffer(t, config.expectedContents)
+		file, err := NewFileBuffer(config.flags, FileBufferOptions{
+			Path: "/file",
+			Client: &delegateDeviceClient{
+				stat: func(path string) (*goadb.DirEntry, error) {
+					return &goadb.DirEntry{
+						Name: "/file",
+						Mode: 0664,
+					}, nil
+				},
+				openRead:  openReadString("hello"),
+				openWrite: openWriteNoop(),
+			},
+		}, &LogEntry{})
 
+		assert.NoError(t, err)
 		assert.NotNil(t, file)
 		assert.Equal(t, config.expectedContents, file.Contents(), "%v", config)
 	}
@@ -47,7 +71,7 @@ func TestNewFileBuffer_OpenWithoutReadFailure(t *testing.T) {
 	}
 }
 
-func TestFileBufferSync(t *testing.T) {
+func TestFileBuffer_LoadFromDevice(t *testing.T) {
 	dev := &delegateDeviceClient{
 		stat: statFiles(&goadb.DirEntry{
 			Name: "/file",
@@ -63,66 +87,50 @@ func TestFileBufferSync(t *testing.T) {
 
 	// Success.
 	dev.openRead = openReadString("world")
-	err := file.Sync(&LogEntry{})
+	err := file.loadFromDevice(&LogEntry{})
 	assert.NoError(t, err)
 	assert.Equal(t, "world", file.Contents())
 
 	// Failure.
 	dev.openRead = openReadError(util.Errorf(util.NetworkError, "fail"))
-	err = file.Sync(&LogEntry{})
+	err = file.loadFromDevice(&LogEntry{})
 	assert.Equal(t, `NetworkError: error opening file stream on device
 caused by NetworkError: fail`, util.ErrorWithCauseChain(err))
 	assert.Equal(t, "world", file.Contents())
 }
 
-func TestFileBufferReadAt(t *testing.T) {
-	file := testSingleRegularFileBuffer(t, "hello world")
+func TestFileBuffer_SaveToDevice(t *testing.T) {
+	var buf *bytes.Buffer
+	dev := &delegateDeviceClient{
+		stat: statFiles(&goadb.DirEntry{
+			Name: "/file",
+			Mode: 0664,
+		}),
+	}
 
-	var buf []byte
-	var n int
-	var err error
+	buf = bytes.NewBufferString("hello world")
+	dev.openWrite = openWriteTo(buf)
+	file := newTestFileBuffer(t, O_WRONLY|O_TRUNC, FileBufferOptions{
+		Path:   "/file",
+		Client: dev,
+	})
+	assert.Equal(t, "", buf.String())
+	assert.Equal(t, "", file.Contents())
 
-	// Read empty buffer.
-	buf = make([]byte, 0)
-	n, err = file.ReadAt(buf, 0)
-	assert.Equal(t, 0, n)
+	// Success.
+	file.WriteAt([]byte("hello world"), 0)
+	err := file.saveToDevice(&LogEntry{})
 	assert.NoError(t, err)
-	assert.Equal(t, "", string(buf))
+	assert.Equal(t, "hello world", file.Contents())
+	assert.Equal(t, "hello world", buf.String())
 
-	// Read less than available.
-	buf = make([]byte, 5)
-	n, err = file.ReadAt(buf, 0)
-	assert.Equal(t, len(buf), n)
-	assert.NoError(t, err)
-	assert.Equal(t, "hello", string(buf))
-
-	// Read exactly available.
-	buf = make([]byte, len("hello world"))
-	n, err = file.ReadAt(buf, 0)
-	assert.Equal(t, len(buf), n)
-	assert.Equal(t, io.EOF, err)
-	assert.Equal(t, "hello world", string(buf))
-
-	// Read from middle of stream.
-	buf = make([]byte, 5)
-	n, err = file.ReadAt(buf, 6)
-	assert.Equal(t, len(buf), n)
-	assert.Equal(t, io.EOF, err)
-	assert.Equal(t, "world", string(buf))
-
-	// Try reading more than available.
-	buf = make([]byte, 1024)
-	n, err = file.ReadAt(buf, 0)
-	assert.Equal(t, len("hello world"), n)
-	assert.Equal(t, io.EOF, err)
-	assert.Equal(t, "hello world", string(buf[:n]))
-
-	// Try reading after last data.
-	buf = make([]byte, 5)
-	n, err = file.ReadAt(buf, 1024)
-	assert.Equal(t, 0, n)
-	assert.Equal(t, io.EOF, err)
-	assert.Equal(t, "", string(buf[:n]))
+	// Failure.
+	dev.openWrite = openWriteError(util.Errorf(util.NetworkError, "fail"))
+	err = file.saveToDevice(&LogEntry{})
+	assert.Equal(t, `NetworkError: error opening file stream on device
+caused by NetworkError: fail`, util.ErrorWithCauseChain(err))
+	assert.Equal(t, "hello world", file.Contents())
+	assert.Equal(t, "hello world", buf.String())
 }
 
 func TestFileBuffer_RefCount(t *testing.T) {
@@ -160,13 +168,116 @@ func TestFileBuffer_RefCount(t *testing.T) {
 	}()
 }
 
+func TestNewFileBuffer_NoExistCreateSuccess(t *testing.T) {
+	file, err := NewFileBuffer(O_RDWR|O_CREATE, FileBufferOptions{
+		Path: "/file",
+		Client: &delegateDeviceClient{
+			stat:      statFiles(),
+			openWrite: openWriteNoop(),
+		},
+	}, &LogEntry{})
+	assert.NoError(t, err)
+	assert.NotNil(t, file)
+}
+
+func TestNewFileBuffer_ModFlagWithoutWriteFailure(t *testing.T) {
+	for _, flags := range []FileOpenFlags{
+		O_CREATE | O_RDONLY,
+		O_TRUNC | O_RDONLY,
+		O_APPEND | O_RDONLY,
+	} {
+		file, err := NewFileBuffer(flags, FileBufferOptions{
+			Path: "/file",
+			Client: &delegateDeviceClient{
+				stat: func(path string) (*goadb.DirEntry, error) {
+					return &goadb.DirEntry{
+						Name: "/file",
+						Mode: 0664,
+					}, nil
+				},
+				openRead: func(path string) (io.ReadCloser, error) {
+					return ioutil.NopCloser(strings.NewReader("hello")), nil
+				},
+			},
+		}, &LogEntry{})
+		assert.Equal(t, ErrNotPermitted, err)
+		assert.Nil(t, file)
+	}
+}
+
+func TestNewFileBuffer_PermsFromCorrectSource(t *testing.T) {
+	const NoExist = DontSetPerms
+	for _, perms := range []struct {
+		// The perms requested in the Open call.
+		Requested os.FileMode
+		// The perms returned by Stat.
+		StatResult os.FileMode
+		Expected   os.FileMode
+	}{
+		{DontSetPerms, 0664, DefaultFilePermissions},
+		{0600, 0664, 0600},
+		{0600, NoExist, 0600},
+		{DontSetPerms, NoExist, DefaultFilePermissions},
+	} {
+		file, err := NewFileBuffer(O_RDWR|O_CREATE, FileBufferOptions{
+			Path:  "/file",
+			Perms: perms.Requested,
+			Client: &delegateDeviceClient{
+				stat: func(path string) (*goadb.DirEntry, error) {
+					if perms.StatResult == NoExist {
+						return nil, util.Errorf(util.FileNoExistError, "fail")
+					}
+					return &goadb.DirEntry{
+						Name: "/file",
+						Mode: perms.StatResult,
+					}, nil
+				},
+				openRead:  openReadString("hello"),
+				openWrite: openWriteNoop(),
+			},
+		}, &LogEntry{})
+		assert.NoError(t, err)
+		assert.NotNil(t, file)
+		actualPerms := file.Perms
+		assert.Equal(t, perms.Expected, actualPerms, "expected %v, got %s", perms, actualPerms)
+	}
+}
+
+func TestFileBuffer_SetSize(t *testing.T) {
+	fbuf, dev := testSingleRegularRdwrFileBuffer(t, "hello world")
+	assert.EqualValues(t, 11, fbuf.Size())
+	assert.False(t, fbuf.IsDirty())
+
+	fbuf.SetSize(0)
+	assert.EqualValues(t, 0, fbuf.Size())
+	assert.True(t, fbuf.IsDirty())
+	assert.Empty(t, dev.String(), "set size shouldn't flush")
+}
+
+func TestFileBuffer_Flush(t *testing.T) {
+	fbuf, dev := testSingleRegularRdwrFileBuffer(t, "hello world")
+	assert.False(t, fbuf.IsDirty())
+	assert.Empty(t, dev.String())
+
+	// Flush is a no-op when not dirty.
+	fbuf.Flush(&LogEntry{})
+	assert.False(t, fbuf.IsDirty())
+	assert.Empty(t, dev.String())
+
+	// Dirty the buffer.
+	fbuf.WriteAt([]byte{}, 0)
+	fbuf.Flush(&LogEntry{})
+	assert.False(t, fbuf.IsDirty())
+	assert.Equal(t, "hello world", dev.String())
+}
+
 func newTestFileBuffer(t *testing.T, flags FileOpenFlags, opts FileBufferOptions) *FileBuffer {
 	f, err := NewFileBuffer(flags, opts, &LogEntry{})
 	assert.NoError(t, err)
 	return f
 }
 
-func testSingleRegularFileBuffer(t *testing.T, contents string) *FileBuffer {
+func testSingleRegularRoFileBuffer(t *testing.T, contents string) *FileBuffer {
 	return newTestFileBuffer(t, O_RDONLY, FileBufferOptions{
 		Path: "/",
 		Client: &delegateDeviceClient{
@@ -177,4 +288,22 @@ func testSingleRegularFileBuffer(t *testing.T, contents string) *FileBuffer {
 			openRead: openReadString(contents),
 		},
 	})
+}
+
+// testSingleRegularRdwrFileBuffer returns a *FileBuffer and a buffer that all saveToDevice calls
+// will write to.
+func testSingleRegularRdwrFileBuffer(t *testing.T, contents string) (*FileBuffer, *bytes.Buffer) {
+	var buf bytes.Buffer
+	return newTestFileBuffer(t, O_RDWR, FileBufferOptions{
+		Path:  "/",
+		Clock: &TestClock,
+		Client: &delegateDeviceClient{
+			stat: statFiles(&goadb.DirEntry{
+				Name: "/",
+				Mode: 0664,
+			}),
+			openRead:  openReadString(contents),
+			openWrite: openWriteTo(&buf),
+		},
+	}), &buf
 }

--- a/file_open_flags.go
+++ b/file_open_flags.go
@@ -33,6 +33,11 @@ func (f FileOpenFlags) CanRead() bool {
 	return !f.Contains(O_WRONLY)
 }
 
+func (f FileOpenFlags) CanWrite() bool {
+	return f.Contains(O_WRONLY | O_RDWR)
+}
+
+// Contains returns true if the current flags contain any of the bits in bits.
 func (f FileOpenFlags) Contains(bits FileOpenFlags) bool {
-	return (f & bits) == bits
+	return (f & bits) != 0
 }

--- a/file_open_flags_test.go
+++ b/file_open_flags_test.go
@@ -11,3 +11,9 @@ func TestFuseOpenFlagsCanRead(t *testing.T) {
 	assert.True(t, O_RDWR.CanRead())
 	assert.False(t, O_WRONLY.CanRead())
 }
+
+func TestFuseOpenFlagsCanWrite(t *testing.T) {
+	assert.True(t, O_WRONLY.CanWrite())
+	assert.True(t, O_RDWR.CanWrite())
+	assert.False(t, O_RDONLY.CanWrite())
+}

--- a/internal/cli/base_config.go
+++ b/internal/cli/base_config.go
@@ -25,6 +25,7 @@ type BaseConfig struct {
 	CacheTtl           time.Duration
 	ServeDebug         bool
 	DeviceRoot         string
+	ReadOnly           bool
 }
 
 const (
@@ -35,6 +36,7 @@ const (
 	VerboseFlag            = "verbose"
 	ServeDebugFlag         = "debug"
 	DeviceRootFlag         = "device-root"
+	ReadOnlyFlag           = "readonly"
 )
 
 func registerBaseFlags(config *BaseConfig) {
@@ -43,6 +45,7 @@ func registerBaseFlags(config *BaseConfig) {
 	kingpin.Flag(CacheTtlFlag, "Duration to keep cached file info.").Default(DefaultCacheTtl.String()).DurationVar(&config.CacheTtl)
 	kingpin.Flag(ServeDebugFlag, "If set, will start an HTTP server to expose profiling and trace logs. Off by default.").BoolVar(&config.ServeDebug)
 	kingpin.Flag(DeviceRootFlag, "The device directory to mount.").Default("/sdcard").StringVar(&config.DeviceRoot)
+	kingpin.Flag(ReadOnlyFlag, "Mount as a readonly filesystem. True by default, since write support is still experimental. Use --no-readonly to enable writes.").Short('r').Default("true").BoolVar(&config.ReadOnly)
 
 	logLevels := []string{
 		logrus.PanicLevel.String(),
@@ -67,6 +70,7 @@ func (c *BaseConfig) AsArgs() []string {
 		formatFlag(ServeDebugFlag, c.ServeDebug),
 		formatFlag(VerboseFlag, c.Verbose),
 		formatFlag(DeviceRootFlag, c.DeviceRoot),
+		formatFlag(ReadOnlyFlag, c.ReadOnly),
 	}
 }
 

--- a/internal/cli/base_config_test.go
+++ b/internal/cli/base_config_test.go
@@ -15,6 +15,7 @@ func TestAdbfsConfigAsArgs(t *testing.T) {
 		CacheTtl:           30 * time.Second,
 		ServeDebug:         true,
 		DeviceRoot:         "/abc",
+		ReadOnly:           true,
 	}
 
 	expectedArgs := []string{
@@ -25,6 +26,7 @@ func TestAdbfsConfigAsArgs(t *testing.T) {
 		"--debug",
 		"--no-verbose",
 		"--device-root=/abc",
+		"--readonly",
 	}
 
 	assert.Equal(t, expectedArgs, config.AsArgs())

--- a/internal/util/atomic_bool.go
+++ b/internal/util/atomic_bool.go
@@ -1,0 +1,23 @@
+package util
+
+import "sync/atomic"
+
+type AtomicBool int32
+
+func (b *AtomicBool) Value() bool {
+	return atomic.LoadInt32((*int32)(b)) != 0
+}
+
+// CompareAndSwap sets the value to newVal iff the current value is oldVal.
+// If the comparison was successful, returns true.
+func (b *AtomicBool) CompareAndSwap(oldVal, newVal bool) (swapped bool) {
+	var oldIntVal int32 = 0
+	if oldVal {
+		oldIntVal = 1
+	}
+	var newIntVal int32 = 0
+	if newVal {
+		newIntVal = 1
+	}
+	return atomic.CompareAndSwapInt32((*int32)(b), oldIntVal, newIntVal)
+}

--- a/internal/util/clock.go
+++ b/internal/util/clock.go
@@ -1,0 +1,40 @@
+package util
+
+import "time"
+
+var (
+	// Wraps time.Now().
+	SystemClock = systemClock{}
+
+	// A mock Clock object that can be used for tests.
+	// Every call to Now() will advance time by 1 nanosecond.
+	// Every test that relies on this should call TestClock.Reset() before using it.
+	TestClock MockClock
+)
+
+type Clock interface {
+	Now() time.Time
+}
+
+type systemClock struct{}
+
+func (systemClock) Now() time.Time {
+	return time.Now()
+}
+
+type MockClock time.Time
+
+func (c *MockClock) Reset() {
+	*c = MockClock(time.Unix(1, 0))
+}
+
+func (c *MockClock) Now() (now time.Time ){
+	now = time.Time(*c)
+	// 2 reads of Now should never return the same value.
+	c.Advance(1 * time.Nanosecond)
+	return
+}
+
+func (c *MockClock) Advance(d time.Duration) {
+	*c = MockClock(time.Time(*c).Add(d))
+}

--- a/internal/util/dirty_timestamp.go
+++ b/internal/util/dirty_timestamp.go
@@ -1,0 +1,39 @@
+package util
+
+import "time"
+
+var zeroTime time.Time
+
+// DirtyTimestamp is a boolean flag that knows the last time it was set from false to true.
+// Zero value is unset.
+type DirtyTimestamp struct {
+	clock Clock
+	t     time.Time
+}
+
+func NewDirtyTimestamp(clock Clock) *DirtyTimestamp {
+	if clock == nil {
+		clock = SystemClock
+	}
+	return &DirtyTimestamp{
+		clock: clock,
+	}
+}
+
+func (ts *DirtyTimestamp) IsSet() bool {
+	return !ts.t.IsZero()
+}
+
+func (ts *DirtyTimestamp) Set() {
+	if ts.t.IsZero() {
+		ts.t = ts.clock.Now()
+	}
+}
+
+func (ts *DirtyTimestamp) Clear() {
+	ts.t = zeroTime
+}
+
+func (ts *DirtyTimestamp) HasBeenDirtyFor(d time.Duration) bool {
+	return ts.IsSet() && ts.t.Add(d).Before(ts.clock.Now())
+}

--- a/internal/util/dirty_timestamp_test.go
+++ b/internal/util/dirty_timestamp_test.go
@@ -1,0 +1,32 @@
+package util
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDirtyTimestamp(t *testing.T) {
+	TestClock.Reset()
+	ts := NewDirtyTimestamp(&TestClock)
+	assert.False(t, ts.IsSet())
+	assert.False(t, ts.HasBeenDirtyFor(0))
+
+	ts.Set()
+	assert.True(t, ts.IsSet())
+	assert.True(t, ts.HasBeenDirtyFor(0))
+	assert.False(t, ts.HasBeenDirtyFor(5*time.Minute))
+
+	ts.Clear()
+	assert.False(t, ts.IsSet())
+
+	// Check timing behavior with multiple sets and elapsed time.
+	ts.Set()
+	TestClock.Advance(501 * time.Millisecond)
+	ts.Set()
+	assert.True(t, ts.HasBeenDirtyFor(0))
+	assert.True(t, ts.HasBeenDirtyFor(250*time.Millisecond))
+	assert.True(t, ts.HasBeenDirtyFor(500*time.Millisecond))
+	assert.False(t, ts.HasBeenDirtyFor(1*time.Second))
+}

--- a/internal/util/growable_byte_slice.go
+++ b/internal/util/growable_byte_slice.go
@@ -1,0 +1,145 @@
+package util
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+)
+
+const (
+	// Once initialized, capacity will never drop below this number.
+	initialGrowableByteSliceCapacity = 1024
+)
+
+/*
+Buffer is used to hold file data in memory.
+Slightly different and simpler behavior than bytes.Buffer.
+Wraps a byte slice, and can grow it preserving existing data,
+truncate it larger or smaller.
+
+Indices are specified in int64s, not ints. Currently the slice is implemented
+as a single underlying byte slice, so math.IntMax is the maximum length.
+*/
+type GrowableByteSlice struct {
+	data []byte
+}
+
+var (
+	// Read interfaces.
+	_ io.ReaderAt = &GrowableByteSlice{}
+	_ io.WriterTo = &GrowableByteSlice{}
+
+	// Write interfaces.
+	_ io.WriterAt   = &GrowableByteSlice{}
+	_ io.ReaderFrom = &GrowableByteSlice{}
+)
+
+func (s *GrowableByteSlice) String() string {
+	return string(s.data)
+}
+
+func (s *GrowableByteSlice) GoString() string {
+	return fmt.Sprintf("GrowableSlice(len=%d,cap=%d)", len(s.data), cap(s.data))
+}
+
+// Resize changes the len of the slice, re-allocating if necessary, to be newLen.
+// If the new len is larger, the "new" bytes at the end of the buffer will always be zeroed out.
+func (s *GrowableByteSlice) Resize(newLen64 int64) {
+	newLen := int(newLen64)
+	switch {
+	case newLen < 0:
+		panic("newLen must be >= 0")
+	case newLen < len(s.data):
+		s.shrink(newLen)
+	case newLen == len(s.data):
+		return
+	case newLen <= cap(s.data):
+		s.data = s.data[:newLen]
+	default: // newLen > cap(s.data)
+		s.reallocate(newLen)
+	}
+}
+
+// shrink returns a byte slice that has len < newLen and the same initial bytes copied from s.data.
+func (s *GrowableByteSlice) shrink(newLen int) {
+	if newLen >= len(s.data) {
+		panic("cannot shrink larger")
+	}
+
+	if len(s.data) < cap(s.data)/3 {
+		// Reallocate to avoid leaking memory.
+		s.reallocate(newLen)
+	} else {
+		// Only shrinking a little, we can re-use the array.
+		// …but zero out the old data so it doesn't leak next time we grow past newLen without reallocating.
+		for i := range s.data[newLen:] {
+			s.data[i] = 0
+		}
+		s.data = s.data[:newLen]
+	}
+}
+
+// reallocate replaces the underlying array with a new array that has len newLen and capacity 2*newLen
+// and copies data over.
+func (s *GrowableByteSlice) reallocate(newLen int) {
+	newCapacity := 2 * newLen
+	if newCapacity < initialGrowableByteSliceCapacity {
+		newCapacity = initialGrowableByteSliceCapacity
+	}
+
+	newData := make([]byte, newLen, newCapacity)
+	copy(newData, s.data)
+	s.data = newData
+}
+
+// ReadAt implements the io.ReaderAt interface.
+func (s *GrowableByteSlice) ReadAt(buf []byte, off int64) (n int, err error) {
+	if off >= int64(len(s.data)) {
+		return 0, io.EOF
+	}
+
+	// Don't use Slice because we don't want to grow the slice.
+	n = copy(buf, s.data[off:])
+	if n+int(off) == len(s.data) {
+		// Didn't copy the entire buffer, so buf must be bigger than the rest of our buffer.
+		err = io.EOF
+	}
+	return
+}
+
+// WriteAt implements the io.WriterAt interface.
+func (s *GrowableByteSlice) WriteAt(data []byte, off int64) (int, error) {
+	end := off + int64(len(data))
+	copy(s.slice(off, end), data)
+	return len(data), nil
+}
+
+// slice returns the bytes in b[start:end], and will
+// grow the slice if end > b.Len().
+func (s *GrowableByteSlice) slice(start, end int64) []byte {
+	if start > end {
+		panic(fmt.Sprintf("start(%d) > end(%d)", start, end))
+	}
+
+	if end > int64(len(s.data)) {
+		s.Resize(int64(end))
+	}
+
+	return s.data[start:end]
+}
+
+func (s *GrowableByteSlice) WriteTo(w io.Writer) (int64, error) {
+	return io.Copy(w, bytes.NewReader(s.data))
+}
+
+// ReadFrom resizes the slice to 0 then reads all of r.
+func (s *GrowableByteSlice) ReadFrom(r io.Reader) (int64, error) {
+	data, err := ioutil.ReadAll(r)
+	s.data = data
+	return int64(len(data)), err
+}
+
+func (s *GrowableByteSlice) Len() int64 {
+	return int64(len(s.data))
+}

--- a/internal/util/growable_byte_slice_test.go
+++ b/internal/util/growable_byte_slice_test.go
@@ -1,0 +1,164 @@
+package util
+
+import (
+	"io"
+	"testing"
+
+	"bytes"
+
+	"github.com/stretchr/testify/assert"
+	"strings"
+)
+
+func TestGrowableByteSlice_ReadAt(t *testing.T) {
+	source := GrowableByteSlice{[]byte("hello world")}
+
+	var buf []byte
+	var n int
+	var err error
+
+	// Read into an empty buffer.
+	buf = make([]byte, 0)
+	n, err = source.ReadAt(buf, 0)
+	assert.Equal(t, 0, n)
+	assert.NoError(t, err)
+	assert.Equal(t, "", string(buf))
+
+	// Read less than available.
+	buf = make([]byte, 5)
+	n, err = source.ReadAt(buf, 0)
+	assert.Equal(t, len(buf), n)
+	assert.NoError(t, err)
+	assert.Equal(t, "hello", string(buf))
+
+	// Read exactly available.
+	buf = make([]byte, len("hello world"))
+	n, err = source.ReadAt(buf, 0)
+	assert.Equal(t, len(buf), n)
+	assert.Equal(t, io.EOF, err)
+	assert.Equal(t, "hello world", string(buf))
+
+	// Read from middle of stream.
+	buf = make([]byte, 5)
+	n, err = source.ReadAt(buf, 6)
+	assert.Equal(t, len(buf), n)
+	assert.Equal(t, io.EOF, err)
+	assert.Equal(t, "world", string(buf))
+
+	// Try reading more than available.
+	buf = make([]byte, 1024)
+	n, err = source.ReadAt(buf, 0)
+	assert.Equal(t, len("hello world"), n)
+	assert.Equal(t, io.EOF, err)
+	assert.Equal(t, "hello world", string(buf[:n]))
+
+	// Try reading after last data.
+	buf = make([]byte, 5)
+	n, err = source.ReadAt(buf, 1024)
+	assert.Equal(t, 0, n)
+	assert.Equal(t, io.EOF, err)
+	assert.Equal(t, "", string(buf[:n]))
+}
+
+func TestGrowableByteSlice_WriteAt(t *testing.T) {
+	var dest *GrowableByteSlice
+	var n int
+	var err error
+
+	// Write to beginning of an empty buffer.
+	dest = new(GrowableByteSlice)
+	n, err = dest.WriteAt([]byte("hello"), 0)
+	assert.NoError(t, err)
+	assert.Equal(t, 5, n)
+	assert.EqualValues(t, 5, dest.Len())
+	assert.Equal(t, "hello", dest.String())
+
+	// Write after beginning of an empty buffer.
+	dest = new(GrowableByteSlice)
+	n, err = dest.WriteAt([]byte("world"), 6)
+	assert.NoError(t, err)
+	assert.Equal(t, 5, n)
+	assert.EqualValues(t, 11, dest.Len())
+	assert.Equal(t, "\000\000\000\000\000\000world", dest.String())
+
+	// Write at beginning of an non-empty buffer.
+	dest = &GrowableByteSlice{[]byte("      world")}
+	n, err = dest.WriteAt([]byte("hello"), 0)
+	assert.NoError(t, err)
+	assert.Equal(t, 5, n)
+	assert.EqualValues(t, 11, dest.Len())
+	assert.Equal(t, "hello world", dest.String())
+
+	// Write at end of an non-empty buffer.
+	dest = &GrowableByteSlice{[]byte("hello ")}
+	n, err = dest.WriteAt([]byte("world"), 6)
+	assert.NoError(t, err)
+	assert.Equal(t, 5, n)
+	assert.EqualValues(t, 11, dest.Len())
+	assert.Equal(t, "hello world", dest.String())
+
+	// Multiple writes.
+	dest = new(GrowableByteSlice)
+	dest.WriteAt([]byte("world"), 6)
+	dest.WriteAt([]byte("hello"), 0)
+	dest.WriteAt([]byte(" "), 5)
+	assert.Equal(t, "hello world", dest.String())
+}
+
+func TestGrowableByteSlice_ReadWrite(t *testing.T) {
+	dest := new(GrowableByteSlice)
+
+	n, err := dest.WriteAt([]byte("a"), 65536)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, n)
+	assert.EqualValues(t, 65537, dest.Len())
+
+	buf := make([]byte, 3)
+	n, err = dest.ReadAt(buf, 65535)
+	assert.Equal(t, 2, n)
+	assert.Equal(t, io.EOF, err)
+	assert.Equal(t, "\000a", string(buf[:n]))
+}
+
+func TestGrowableByteSlice_Resize(t *testing.T) {
+	dest := new(GrowableByteSlice)
+	assert.EqualValues(t, 0, dest.Len())
+
+	// Basic length check.
+	dest.Resize(100)
+	assert.EqualValues(t, 100, dest.Len())
+
+	// Check that data is preserved during resize.
+	dest = new(GrowableByteSlice)
+	dest.WriteAt([]byte{'a'}, 0)
+	dest.Resize(100)
+	dest.WriteAt([]byte{'b'}, 100)
+	dest.Resize(200)
+	assert.EqualValues(t, 'a', dest.data[0])
+	assert.EqualValues(t, 'b', dest.data[100])
+	assert.Equal(t, bytes.Repeat([]byte{0}, 99), dest.data[1:100])
+	assert.Equal(t, bytes.Repeat([]byte{0}, 99), dest.data[101:200])
+
+	// Check that old data isn't leaked.
+	dest = new(GrowableByteSlice)
+	dest.WriteAt([]byte("hello"), 100)
+	dest.Resize(0)
+	dest.Resize(200)
+	assert.Equal(t, bytes.Repeat([]byte{0}, 200), dest.data)
+}
+
+func TestGrowableByteSlice_WriteTo(t *testing.T) {
+	data := &GrowableByteSlice{[]byte("hello world")}
+	var buf bytes.Buffer
+	n, _ := data.WriteTo(&buf)
+	assert.EqualValues(t, 11, n)
+	assert.Equal(t, "hello world", buf.String())
+}
+
+func TestGrowableByteSlice_ReadFrom(t *testing.T) {
+	data := new(GrowableByteSlice)
+	buf := strings.NewReader("hello world")
+	n, _ := data.ReadFrom(buf)
+	assert.EqualValues(t, 11, n)
+	assert.Equal(t, "hello world", data.String())
+}

--- a/open_files.go
+++ b/open_files.go
@@ -1,14 +1,20 @@
 package adbfs
 
 import (
+	"os"
 	"sync"
+	"time"
 
 	"github.com/zach-klippenstein/adbfs/internal/cli"
 )
 
 type OpenFilesOptions struct {
-	DeviceSerial  string
-	ClientFactory DeviceClientFactory
+	DeviceSerial       string
+	DefaultPermissions os.FileMode
+	ClientFactory      DeviceClientFactory
+
+	// The length of time the file can be dirty before the next write will force a flush.
+	DirtyTimeout time.Duration
 }
 
 // OpenFiles tracks and manages the set of all open files in a filesystem.
@@ -20,20 +26,26 @@ type OpenFiles struct {
 }
 
 func NewOpenFiles(opts OpenFilesOptions) *OpenFiles {
+	if opts.DirtyTimeout.Nanoseconds() == 0 {
+		opts.DirtyTimeout = DefaultDirtyTimeout
+	}
+
 	return &OpenFiles{
 		OpenFilesOptions: opts,
 		buffersByPath:    make(map[string]*FileBuffer),
 	}
 }
 
-func (f *OpenFiles) GetOrLoad(path string, openFlags FileOpenFlags, logEntry *LogEntry) (file *FileBuffer, err error) {
+func (f *OpenFiles) GetOrLoad(path string, openFlags FileOpenFlags, perms os.FileMode, logEntry *LogEntry) (file *FileBuffer, err error) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
 	if file = f.buffersByPath[path]; file == nil {
 		file, err = NewFileBuffer(openFlags, FileBufferOptions{
 			Path:                path,
-			Client:              f.OpenFilesOptions.ClientFactory(),
+			Client:              f.ClientFactory(),
+			DirtyTimeout:        f.DirtyTimeout,
+			Perms:               perms,
 			ZeroRefCountHandler: f.release,
 		}, logEntry)
 		if err != nil {
@@ -61,5 +73,9 @@ func (f *OpenFiles) release(file *FileBuffer) {
 	}
 
 	cli.Log.Debugf("OpenFiles: releasing FileBuffer for %s", file.Path)
+	if file.IsDirty() {
+		cli.Log.Warnln("OpenFiles: FileBuffer released while still dirty:", file)
+	}
+
 	delete(f.buffersByPath, file.Path)
 }

--- a/open_files_test.go
+++ b/open_files_test.go
@@ -19,13 +19,13 @@ func TestOpenFiles_GetOrLoadSameFileSeparate(t *testing.T) {
 		ClientFactory: func() DeviceClient { return dev },
 	})
 
-	f1, err := o.GetOrLoad("/", O_RDONLY, &LogEntry{})
+	f1, err := o.GetOrLoad("/", O_RDONLY, 0, &LogEntry{})
 	assert.NoError(t, err)
 	assert.Equal(t, 1, f1.RefCount())
 
 	f1.DecRefCount()
 
-	f2, err := o.GetOrLoad("/", O_RDONLY, &LogEntry{})
+	f2, err := o.GetOrLoad("/", O_RDONLY, 0, &LogEntry{})
 	assert.NoError(t, err)
 	assert.NotEqual(t, f1, f2)
 	assert.Equal(t, 1, f2.RefCount())
@@ -44,11 +44,11 @@ func TestOpenFiles_GetOrLoadSameFileShared(t *testing.T) {
 		ClientFactory: func() DeviceClient { return dev },
 	})
 
-	f1, err := o.GetOrLoad("/", O_RDONLY, &LogEntry{})
+	f1, err := o.GetOrLoad("/", O_RDONLY, 0, &LogEntry{})
 	assert.NoError(t, err)
 	assert.Equal(t, 1, f1.RefCount())
 
-	f2, err := o.GetOrLoad("/", O_RDONLY, &LogEntry{})
+	f2, err := o.GetOrLoad("/", O_RDONLY, 0, &LogEntry{})
 	assert.NoError(t, err)
 	assert.Equal(t, f1, f2)
 	assert.Equal(t, 2, f2.RefCount())
@@ -58,7 +58,7 @@ func TestOpenFiles_GetOrLoadSameFileShared(t *testing.T) {
 	assert.Equal(t, 1, f2.RefCount())
 	assert.Equal(t, 1, f1.RefCount())
 
-	f3, err := o.GetOrLoad("/", O_RDONLY, &LogEntry{})
+	f3, err := o.GetOrLoad("/", O_RDONLY, 0, &LogEntry{})
 	assert.NoError(t, err)
 	assert.Equal(t, f2, f3)
 	assert.Equal(t, 2, f3.RefCount())

--- a/util.go
+++ b/util.go
@@ -4,32 +4,11 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"sync/atomic"
 
 	"github.com/hanwen/go-fuse/fuse"
 	"github.com/hanwen/go-fuse/fuse/nodefs"
 	"github.com/zach-klippenstein/goadb"
 )
-
-type AtomicBool int32
-
-func (b *AtomicBool) Value() bool {
-	return atomic.LoadInt32((*int32)(b)) != 0
-}
-
-// CompareAndSwap sets the value to newVal iff the current value is oldVal.
-// If the comparison was successful, returns true.
-func (b *AtomicBool) CompareAndSwap(oldVal, newVal bool) (swapped bool) {
-	var oldIntVal int32 = 0
-	if oldVal {
-		oldIntVal = 1
-	}
-	var newIntVal int32 = 0
-	if newVal {
-		newIntVal = 1
-	}
-	return atomic.CompareAndSwapInt32((*int32)(b), oldIntVal, newIntVal)
-}
 
 // asFuseDirEntries reads directory entries from a goadb DirEntries and returns them as a
 // list of fuse DirEntry objects.

--- a/vendor/github.com/zach-klippenstein/goadb/.travis.yml
+++ b/vendor/github.com/zach-klippenstein/goadb/.travis.yml
@@ -1,4 +1,5 @@
 language: go
 
 go:
-  - 1.4
+  - 1.5.1
+  - tip

--- a/vendor/github.com/zach-klippenstein/goadb/README.md
+++ b/vendor/github.com/zach-klippenstein/goadb/README.md
@@ -1,6 +1,6 @@
 #goadb
 
-[![Build Status](https://travis-ci.org/zach-klippenstein/goadb.svg)](https://travis-ci.org/zach-klippenstein/goadb)
+[![Build Status](https://travis-ci.org/zach-klippenstein/goadb.svg?branch=master)](https://travis-ci.org/zach-klippenstein/goadb)
 [![GoDoc](https://godoc.org/github.com/zach-klippenstein/goadb?status.svg)](https://godoc.org/github.com/zach-klippenstein/goadb)
 
 A Golang library for interacting with the Android Debug Bridge (adb).

--- a/vendor/github.com/zach-klippenstein/goadb/cmd/adb/main.go
+++ b/vendor/github.com/zach-klippenstein/goadb/cmd/adb/main.go
@@ -1,0 +1,252 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/cheggaaa/pb"
+	"github.com/zach-klippenstein/goadb"
+	"github.com/zach-klippenstein/goadb/util"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+const StdIoFilename = "-"
+
+var (
+	serial = kingpin.Flag("serial", "Connect to device by serial number.").Short('s').String()
+
+	shellCommand    = kingpin.Command("shell", "Run a shell command on the device.")
+	shellCommandArg = shellCommand.Arg("command", "Command to run on device.").Strings()
+
+	devicesCommand  = kingpin.Command("devices", "List devices.")
+	devicesLongFlag = devicesCommand.Flag("long", "Include extra detail about devices.").Short('l').Bool()
+
+	pullCommand      = kingpin.Command("pull", "Pull a file from the device.")
+	pullProgressFlag = pullCommand.Flag("progress", "Show progress.").Short('p').Bool()
+	pullRemoteArg    = pullCommand.Arg("remote", "Path of source file on device.").Required().String()
+	pullLocalArg     = pullCommand.Arg("local", "Path of destination file. If -, will write to stdout.").String()
+
+	pushCommand      = kingpin.Command("push", "Push a file to the device.")
+	pushProgressFlag = pushCommand.Flag("progress", "Show progress.").Short('p').Bool()
+	pushLocalArg     = pushCommand.Arg("local", "Path of source file. If -, will read from stdin.").Required().String()
+	pushRemoteArg    = pushCommand.Arg("remote", "Path of destination file on device.").Required().String()
+)
+
+func main() {
+	var exitCode int
+
+	switch kingpin.Parse() {
+	case "devices":
+		exitCode = listDevices(*devicesLongFlag)
+	case "shell":
+		exitCode = runShellCommand(*shellCommandArg, parseDevice())
+	case "pull":
+		exitCode = pull(*pullProgressFlag, *pullRemoteArg, *pullLocalArg, parseDevice())
+	case "push":
+		exitCode = push(*pushProgressFlag, *pushLocalArg, *pushRemoteArg, parseDevice())
+	}
+
+	os.Exit(exitCode)
+}
+
+func parseDevice() goadb.DeviceDescriptor {
+	if *serial != "" {
+		return goadb.DeviceWithSerial(*serial)
+	}
+
+	return goadb.AnyDevice()
+}
+
+func listDevices(long bool) int {
+	client := goadb.NewHostClient(goadb.ClientConfig{})
+	devices, err := client.ListDevices()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+	}
+
+	for _, device := range devices {
+		if long {
+			if device.Usb == "" {
+				fmt.Printf("%s\tproduct:%s model:%s device:%s\n",
+					device.Serial, device.Product, device.Model, device.DeviceInfo)
+			} else {
+				fmt.Printf("%s\tusb:%s product:%s model:%s device:%s\n",
+					device.Serial, device.Usb, device.Product, device.Model, device.DeviceInfo)
+			}
+		} else {
+			fmt.Println(device.Serial)
+		}
+	}
+
+	return 0
+}
+
+func runShellCommand(commandAndArgs []string, device goadb.DeviceDescriptor) int {
+	if len(commandAndArgs) == 0 {
+		fmt.Fprintln(os.Stderr, "error: no command")
+		kingpin.Usage()
+		return 1
+	}
+
+	command := commandAndArgs[0]
+	var args []string
+
+	if len(commandAndArgs) > 1 {
+		args = commandAndArgs[1:]
+	}
+
+	client := goadb.NewDeviceClient(goadb.ClientConfig{}, device)
+	output, err := client.RunCommand(command, args...)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		return 1
+	}
+
+	fmt.Print(output)
+	return 0
+}
+
+func pull(showProgress bool, remotePath, localPath string, device goadb.DeviceDescriptor) int {
+	if remotePath == "" {
+		fmt.Fprintln(os.Stderr, "error: must specify remote file")
+		kingpin.Usage()
+		return 1
+	}
+
+	if localPath == "" {
+		localPath = filepath.Base(remotePath)
+	}
+
+	client := goadb.NewDeviceClient(goadb.ClientConfig{}, device)
+
+	info, err := client.Stat(remotePath)
+	if util.HasErrCode(err, util.FileNoExistError) {
+		fmt.Fprintln(os.Stderr, "remote file does not exist:", remotePath)
+		return 1
+	} else if err != nil {
+		fmt.Fprintf(os.Stderr, "error reading remote file %s: %s\n", remotePath, err)
+		return 1
+	}
+
+	remoteFile, err := client.OpenRead(remotePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error opening remote file %s: %s\n", remotePath, util.ErrorWithCauseChain(err))
+		return 1
+	}
+	defer remoteFile.Close()
+
+	var localFile io.WriteCloser
+	if localPath == StdIoFilename {
+		localFile = os.Stdout
+	} else {
+		localFile, err = os.Create(localPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error opening local file %s: %s\n", localPath, err)
+			return 1
+		}
+	}
+	defer localFile.Close()
+
+	if err := copyWithProgressAndStats(localFile, remoteFile, int(info.Size), showProgress); err != nil {
+		fmt.Fprintln(os.Stderr, "error pulling file:", err)
+		return 1
+	}
+	return 0
+}
+
+func push(showProgress bool, localPath, remotePath string, device goadb.DeviceDescriptor) int {
+	if remotePath == "" {
+		fmt.Fprintln(os.Stderr, "error: must specify remote file")
+		kingpin.Usage()
+		return 1
+	}
+
+	var (
+		localFile io.ReadCloser
+		size      int
+		perms     os.FileMode
+		mtime     time.Time
+	)
+	if localPath == "" || localPath == StdIoFilename {
+		localFile = os.Stdin
+		// 0 size will hide the progress bar.
+		perms = os.FileMode(0660)
+		mtime = goadb.MtimeOfClose
+	} else {
+		var err error
+		localFile, err = os.Open(localPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error opening local file %s: %s\n", localPath, err)
+			return 1
+		}
+		info, err := os.Stat(localPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error reading local file %s: %s\n", localPath, err)
+			return 1
+		}
+		size = int(info.Size())
+		perms = info.Mode().Perm()
+		mtime = info.ModTime()
+	}
+	defer localFile.Close()
+
+	client := goadb.NewDeviceClient(goadb.ClientConfig{}, device)
+	writer, err := client.OpenWrite(remotePath, perms, mtime)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error opening remote file %s: %s\n", remotePath, err)
+		return 1
+	}
+	defer writer.Close()
+
+	if err := copyWithProgressAndStats(writer, localFile, size, showProgress); err != nil {
+		fmt.Fprintln(os.Stderr, "error pushing file:", err)
+		return 1
+	}
+	return 0
+}
+
+// copyWithProgressAndStats copies src to dst.
+// If showProgress is true and size is positive, a progress bar is shown.
+// After copying, final stats about the transfer speed and size are shown.
+// Progress and stats are printed to stderr.
+func copyWithProgressAndStats(dst io.Writer, src io.Reader, size int, showProgress bool) error {
+	var progress *pb.ProgressBar
+	if showProgress && size > 0 {
+		progress = pb.New(size)
+		// Write to stderr in case dst is stdout.
+		progress.Output = os.Stderr
+		progress.ShowSpeed = true
+		progress.ShowPercent = true
+		progress.ShowTimeLeft = true
+		progress.SetUnits(pb.U_BYTES)
+		progress.Start()
+		dst = io.MultiWriter(dst, progress)
+	}
+
+	startTime := time.Now()
+	copied, err := io.Copy(dst, src)
+
+	if progress != nil {
+		progress.Finish()
+	}
+
+	if pathErr, ok := err.(*os.PathError); ok {
+		if errno, ok := pathErr.Err.(syscall.Errno); ok && errno == syscall.EPIPE {
+			// Pipe closed. Handle this like an EOF.
+			err = nil
+		}
+	}
+	if err != nil {
+		return err
+	}
+
+	duration := time.Now().Sub(startTime)
+	rate := int64(float64(copied) / duration.Seconds())
+	fmt.Fprintf(os.Stderr, "%d B/s (%d bytes in %s)\n", rate, copied, duration)
+
+	return nil
+}

--- a/vendor/github.com/zach-klippenstein/goadb/cmd/raw-adb/raw-adb.go
+++ b/vendor/github.com/zach-klippenstein/goadb/cmd/raw-adb/raw-adb.go
@@ -59,7 +59,7 @@ func doCommand(cmd string) error {
 		return err
 	}
 
-	status, err := conn.ReadStatus()
+	status, err := conn.ReadStatus("")
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/zach-klippenstein/goadb/device_watcher.go
+++ b/vendor/github.com/zach-klippenstein/goadb/device_watcher.go
@@ -180,7 +180,7 @@ func connectToTrackDevices(dialer Dialer) (wire.Scanner, error) {
 		return nil, err
 	}
 
-	if err := wire.ReadStatusFailureAsError(conn, "host:track-devices"); err != nil {
+	if _, err := conn.ReadStatus("host:track-devices"); err != nil {
 		conn.Close()
 		return nil, err
 	}

--- a/vendor/github.com/zach-klippenstein/goadb/dir_entries.go
+++ b/vendor/github.com/zach-klippenstein/goadb/dir_entries.go
@@ -74,16 +74,16 @@ func (entries *DirEntries) Close() error {
 }
 
 func readNextDirListEntry(s wire.SyncScanner) (entry *DirEntry, done bool, err error) {
-	id, err := s.ReadOctetString()
+	status, err := s.ReadStatus("dir-entry")
 	if err != nil {
 		return
 	}
 
-	if id == "DONE" {
+	if status == "DONE" {
 		done = true
 		return
-	} else if id != "DENT" {
-		err = fmt.Errorf("error reading dir entries: expected dir entry ID 'DENT', but got '%s'", id)
+	} else if status != "DENT" {
+		err = fmt.Errorf("error reading dir entries: expected dir entry ID 'DENT', but got '%s'", status)
 		return
 	}
 

--- a/vendor/github.com/zach-klippenstein/goadb/host_client_test.go
+++ b/vendor/github.com/zach-klippenstein/goadb/host_client_test.go
@@ -32,7 +32,7 @@ type MockServer struct {
 	// but not returned.
 	Errs []error
 
-	Status wire.StatusCode
+	Status string
 
 	// Messages are returned from read calls in order, each preceded by a length header.
 	Messages     []string
@@ -53,7 +53,7 @@ func (s *MockServer) Dial() (*wire.Conn, error) {
 	return wire.NewConn(s, s), nil
 }
 
-func (s *MockServer) ReadStatus() (wire.StatusCode, error) {
+func (s *MockServer) ReadStatus(req string) (string, error) {
 	s.logMethod("ReadStatus")
 	if err := s.getNextErrToReturn(); err != nil {
 		return "", err

--- a/vendor/github.com/zach-klippenstein/goadb/sync_file_reader.go
+++ b/vendor/github.com/zach-klippenstein/goadb/sync_file_reader.go
@@ -1,9 +1,9 @@
 package goadb
 
 import (
-	"fmt"
 	"io"
 
+	"github.com/zach-klippenstein/goadb/util"
 	"github.com/zach-klippenstein/goadb/wire"
 )
 
@@ -14,25 +14,54 @@ type syncFileReader struct {
 
 	// Reader for the current chunk only.
 	chunkReader io.Reader
+
+	// False until the DONE chunk is encountered.
+	eof bool
 }
 
 var _ io.ReadCloser = &syncFileReader{}
 
-func newSyncFileReader(s wire.SyncScanner) io.ReadCloser {
-	return &syncFileReader{
+func newSyncFileReader(s wire.SyncScanner) (r io.ReadCloser, err error) {
+	r = &syncFileReader{
 		scanner: s,
 	}
+
+	// Read the header for the first chunk to consume any errors.
+	if _, err = r.Read([]byte{}); err != nil {
+		if err == io.EOF {
+			// EOF means the file was empty. This still means the file was opened successfully,
+			// and the next time the caller does a read they'll get the EOF and handle it themselves.
+			err = nil
+		} else {
+			r.Close()
+			return nil, err
+		}
+	}
+	return
 }
 
 func (r *syncFileReader) Read(buf []byte) (n int, err error) {
+	if r.eof {
+		return 0, io.EOF
+	}
+
 	if r.chunkReader == nil {
 		chunkReader, err := readNextChunk(r.scanner)
 		if err != nil {
-			// If this is EOF, we've read the last chunk.
-			// Either way, we want to pass it up to the caller.
+			if err == io.EOF {
+				// We just read the last chunk, set our flag before passing it up.
+				r.eof = true
+			}
 			return 0, err
 		}
 		r.chunkReader = chunkReader
+	}
+
+	if len(buf) == 0 {
+		// Read can be called with an empty buffer to read the next chunk and check for errors.
+		// However, net.Conn.Read seems to return EOF when given an empty buffer, so we need to
+		// handle that case ourselves.
+		return 0, nil
 	}
 
 	n, err = r.chunkReader.Read(buf)
@@ -53,17 +82,27 @@ func (r *syncFileReader) Close() error {
 // readNextChunk creates an io.LimitedReader for the next chunk of data,
 // and returns io.EOF if the last chunk has been read.
 func readNextChunk(r wire.SyncScanner) (io.Reader, error) {
-	id, err := r.ReadOctetString()
+	status, err := r.ReadStatus("read-chunk")
 	if err != nil {
+		if wire.IsAdbServerErrorMatching(err, readFileNotFoundPredicate) {
+			return nil, util.Errorf(util.FileNoExistError, "no such file or directory")
+		}
 		return nil, err
 	}
 
-	switch id {
-	case "DATA":
+	switch status {
+	case wire.StatusSyncData:
 		return r.ReadBytes()
-	case "DONE":
+	case wire.StatusSyncDone:
 		return nil, io.EOF
 	default:
-		return nil, fmt.Errorf("expected chunk id 'DATA', but got '%s'", id)
+		return nil, util.Errorf(util.AssertionError, "expected chunk id '%s' or '%s', but got '%s'",
+			wire.StatusSyncData, wire.StatusSyncDone, []byte(status))
 	}
+}
+
+// readFileNotFoundPredicate returns true if s is the adb server error message returned
+// when trying to open a file that doesn't exist.
+func readFileNotFoundPredicate(s string) bool {
+	return s == "No such file or directory"
 }

--- a/vendor/github.com/zach-klippenstein/goadb/sync_file_reader_test.go
+++ b/vendor/github.com/zach-klippenstein/goadb/sync_file_reader_test.go
@@ -6,7 +6,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/zach-klippenstein/goadb/util"
 	"github.com/zach-klippenstein/goadb/wire"
+	"io/ioutil"
 )
 
 func TestReadNextChunk(t *testing.T) {
@@ -43,16 +45,17 @@ func TestReadNextChunkInvalidChunkId(t *testing.T) {
 
 	// Read 1st chunk
 	_, err := readNextChunk(s)
-	assert.EqualError(t, err, "expected chunk id 'DATA', but got 'ATAD'")
+	assert.EqualError(t, err, "AssertionError: expected chunk id 'DATA' or 'DONE', but got 'ATAD'")
 }
 
 func TestReadMultipleCalls(t *testing.T) {
 	s := wire.NewSyncScanner(strings.NewReader(
 		"DATA\006\000\000\000hello DATA\005\000\000\000worldDONE"))
-	reader := newSyncFileReader(s)
+	reader, err := newSyncFileReader(s)
+	assert.NoError(t, err)
 
 	firstByte := make([]byte, 1)
-	_, err := io.ReadFull(reader, firstByte)
+	_, err = io.ReadFull(reader, firstByte)
 	assert.NoError(t, err)
 	assert.Equal(t, "h", string(firstByte))
 
@@ -73,10 +76,40 @@ func TestReadMultipleCalls(t *testing.T) {
 func TestReadAll(t *testing.T) {
 	s := wire.NewSyncScanner(strings.NewReader(
 		"DATA\006\000\000\000hello DATA\005\000\000\000worldDONE"))
-	reader := newSyncFileReader(s)
+	reader, err := newSyncFileReader(s)
+	assert.NoError(t, err)
 
 	buf := make([]byte, 20)
-	_, err := io.ReadFull(reader, buf)
+	_, err = io.ReadFull(reader, buf)
 	assert.Equal(t, io.ErrUnexpectedEOF, err)
 	assert.Equal(t, "hello world\000", string(buf[:12]))
+}
+
+func TestReadError(t *testing.T) {
+	s := wire.NewSyncScanner(strings.NewReader(
+		"FAIL\004\000\000\000fail"))
+	_, err := newSyncFileReader(s)
+	assert.EqualError(t, err, "AdbError: server error for read-chunk request: fail ({Request:read-chunk ServerMsg:fail})")
+}
+
+func TestReadEmpty(t *testing.T) {
+	s := wire.NewSyncScanner(strings.NewReader(
+		"DONE"))
+	r, err := newSyncFileReader(s)
+	assert.NoError(t, err)
+
+	// Multiple read calls that return EOF is a valid case.
+	for i := 0; i < 5; i++ {
+		data, err := ioutil.ReadAll(r)
+		assert.NoError(t, err)
+		assert.Empty(t, data)
+	}
+}
+
+func TestReadErrorNotFound(t *testing.T) {
+	s := wire.NewSyncScanner(strings.NewReader(
+		"FAIL\031\000\000\000No such file or directory"))
+	_, err := newSyncFileReader(s)
+	assert.True(t, util.HasErrCode(err, util.FileNoExistError))
+	assert.EqualError(t, err, "FileNoExistError: no such file or directory")
 }

--- a/vendor/github.com/zach-klippenstein/goadb/sync_file_writer.go
+++ b/vendor/github.com/zach-klippenstein/goadb/sync_file_writer.go
@@ -1,0 +1,86 @@
+package goadb
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/zach-klippenstein/goadb/util"
+	"github.com/zach-klippenstein/goadb/wire"
+)
+
+// syncFileWriter wraps a SyncConn that has requested to send a file.
+type syncFileWriter struct {
+	// The modification time to write in the footer.
+	// If 0, use the current time.
+	mtime time.Time
+
+	// Reader used to read data from the adb connection.
+	sender wire.SyncSender
+}
+
+var _ io.WriteCloser = &syncFileWriter{}
+
+func newSyncFileWriter(s wire.SyncSender, mtime time.Time) io.WriteCloser {
+	return &syncFileWriter{
+		mtime:  mtime,
+		sender: s,
+	}
+}
+
+/*
+encodePathAndMode encodes a path and file mode as required for starting a send file stream.
+
+From https://android.googlesource.com/platform/system/core/+/master/adb/SYNC.TXT:
+	The remote file name is split into two parts separated by the last
+	comma (","). The first part is the actual path, while the second is a decimal
+	encoded file mode containing the permissions of the file on device.
+*/
+func encodePathAndMode(path string, mode os.FileMode) []byte {
+	return []byte(fmt.Sprintf("%s,%d", path, uint32(mode.Perm())))
+}
+
+// Write writes the min of (len(buf), 64k).
+func (w *syncFileWriter) Write(buf []byte) (n int, err error) {
+	written := 0
+
+	// If buf > 64k we'll have to send multiple chunks.
+	// TODO Refactor this into something that can coalesce smaller writes into a single chukn.
+	for len(buf) > 0 {
+		// Writes < 64k have a one-to-one mapping to chunks.
+		// If buffer is larger than the max, we'll return the max size and leave it up to the
+		// caller to handle correctly.
+		partialBuf := buf
+		if len(partialBuf) > wire.SyncMaxChunkSize {
+			partialBuf = partialBuf[:wire.SyncMaxChunkSize]
+		}
+
+		if err := w.sender.SendOctetString(wire.StatusSyncData); err != nil {
+			return written, err
+		}
+		if err := w.sender.SendBytes(partialBuf); err != nil {
+			return written, err
+		}
+
+		written += len(partialBuf)
+		buf = buf[len(partialBuf):]
+	}
+
+	return written, nil
+}
+
+func (w *syncFileWriter) Close() error {
+	if w.mtime.IsZero() {
+		w.mtime = time.Now()
+	}
+
+	if err := w.sender.SendOctetString(wire.StatusSyncDone); err != nil {
+		return util.WrapErrf(err, "error sending done chunk to close stream")
+	}
+	if err := w.sender.SendTime(w.mtime); err != nil {
+		return util.WrapErrf(err, "error writing file modification time")
+	}
+
+	return util.WrapErrf(w.sender.Close(), "error closing FileWriter")
+}

--- a/vendor/github.com/zach-klippenstein/goadb/sync_file_writer_test.go
+++ b/vendor/github.com/zach-klippenstein/goadb/sync_file_writer_test.go
@@ -1,0 +1,101 @@
+package goadb
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"encoding/binary"
+	"strings"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zach-klippenstein/goadb/wire"
+)
+
+func TestFileWriterWriteSingleChunk(t *testing.T) {
+	var buf bytes.Buffer
+	writer := newSyncFileWriter(wire.NewSyncSender(&buf), MtimeOfClose)
+
+	n, err := writer.Write([]byte("hello"))
+	assert.NoError(t, err)
+	assert.Equal(t, 5, n)
+
+	assert.Equal(t, "DATA\005\000\000\000hello", buf.String())
+}
+
+func TestFileWriterWriteMultiChunk(t *testing.T) {
+	var buf bytes.Buffer
+	writer := newSyncFileWriter(wire.NewSyncSender(&buf), MtimeOfClose)
+
+	n, err := writer.Write([]byte("hello"))
+	assert.NoError(t, err)
+	assert.Equal(t, 5, n)
+
+	n, err = writer.Write([]byte(" world"))
+	assert.NoError(t, err)
+	assert.Equal(t, 6, n)
+
+	assert.Equal(t, "DATA\005\000\000\000helloDATA\006\000\000\000 world", buf.String())
+}
+
+func TestFileWriterWriteLargeChunk(t *testing.T) {
+	var buf bytes.Buffer
+	writer := newSyncFileWriter(wire.NewSyncSender(&buf), MtimeOfClose)
+
+	// Send just enough data to get 2 chunks.
+	data := make([]byte, wire.SyncMaxChunkSize+1)
+	n, err := writer.Write(data)
+
+	assert.NoError(t, err)
+	assert.Equal(t, wire.SyncMaxChunkSize+1, n)
+	assert.Equal(t, 8 + 8 + wire.SyncMaxChunkSize+1, buf.Len())
+
+	// First header.
+	chunk := buf.Bytes()[:8+wire.SyncMaxChunkSize]
+	expectedHeader := []byte("DATA----")
+	binary.LittleEndian.PutUint32(expectedHeader[4:], wire.SyncMaxChunkSize)
+	assert.Equal(t, expectedHeader, chunk[:8])
+	assert.Equal(t, data[:wire.SyncMaxChunkSize], chunk[8:])
+
+	// Second header.
+	chunk = buf.Bytes()[wire.SyncMaxChunkSize+8:wire.SyncMaxChunkSize+8+1]
+	expectedHeader = []byte("DATA\000\000\000\000")
+	binary.LittleEndian.PutUint32(expectedHeader[4:], 1)
+	assert.Equal(t, expectedHeader, chunk[:8])
+}
+
+func TestFileWriterCloseEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	mtime := time.Unix(1, 0)
+	writer := newSyncFileWriter(wire.NewSyncSender(&buf), mtime)
+
+	assert.NoError(t, writer.Close())
+
+	assert.Equal(t, "DONE\x01\x00\x00\x00", buf.String())
+}
+
+func TestFileWriterWriteClose(t *testing.T) {
+	var buf bytes.Buffer
+	mtime := time.Unix(1, 0)
+	writer := newSyncFileWriter(wire.NewSyncSender(&buf), mtime)
+
+	writer.Write([]byte("hello"))
+	assert.NoError(t, writer.Close())
+
+	assert.Equal(t, "DATA\005\000\000\000helloDONE\x01\x00\x00\x00", buf.String())
+}
+
+func TestFileWriterCloseAutoMtime(t *testing.T) {
+	var buf bytes.Buffer
+	writer := newSyncFileWriter(wire.NewSyncSender(&buf), MtimeOfClose)
+
+	assert.NoError(t, writer.Close())
+	assert.Len(t, buf.String(), 8)
+	assert.True(t, strings.HasPrefix(buf.String(), "DONE"))
+
+	mtimeBytes := buf.Bytes()[4:]
+	mtimeActual := time.Unix(int64(binary.LittleEndian.Uint32(mtimeBytes)), 0)
+
+	// Delta has to be a whole second since adb only supports second granularity for mtimes.
+	assert.WithinDuration(t, time.Now(), mtimeActual, 1*time.Second)
+}

--- a/vendor/github.com/zach-klippenstein/goadb/util.go
+++ b/vendor/github.com/zach-klippenstein/goadb/util.go
@@ -26,7 +26,7 @@ func wrapClientError(err error, client interface{}, operation string, args ...in
 		return nil
 	}
 	if _, ok := err.(*util.Err); !ok {
-		panic("err is not a *util.Err")
+		panic("err is not a *util.Err: " + err.Error())
 	}
 
 	clientType := reflect.TypeOf(client)

--- a/vendor/github.com/zach-klippenstein/goadb/util/error.go
+++ b/vendor/github.com/zach-klippenstein/goadb/util/error.go
@@ -77,6 +77,44 @@ func WrapErrf(cause error, format string, args ...interface{}) error {
 	}
 }
 
+// CombineErrs returns an error that wraps all the non-nil errors passed to it.
+// If all errors are nil, returns nil.
+// If there's only one non-nil error, returns that error without wrapping.
+// Else, returns an error with the message and code as passed, with the cause set to an error
+// that contains all the non-nil errors and for which Error() returns the concatenation of all their messages.
+func CombineErrs(msg string, code ErrCode, errs ...error) error {
+	var nonNilErrs []error
+	for _, err := range errs {
+		if err != nil {
+			nonNilErrs = append(nonNilErrs, err)
+		}
+	}
+
+	switch len(nonNilErrs) {
+	case 0:
+		return nil
+	case 1:
+		return nonNilErrs[0]
+	default:
+		return WrapErrorf(multiError(nonNilErrs), code, "%s", msg)
+	}
+}
+
+type multiError []error
+
+func (errs multiError) Error() string {
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "%d errors: [", len(errs))
+	for i, err := range errs {
+		buf.WriteString(err.Error())
+		if i < len(errs)-1 {
+			buf.WriteString(" ∪ ")
+		}
+	}
+	buf.WriteRune(']')
+	return buf.String()
+}
+
 /*
 WrapErrorf returns an *Err that wraps another arbitrary error with an ErrCode and a message.
 
@@ -138,7 +176,12 @@ func ErrorWithCauseChain(err error) string {
 			break
 		}
 	}
-	buffer.WriteString(err.Error())
+
+	if err != nil {
+		buffer.WriteString(err.Error())
+	} else {
+		buffer.WriteString("<err=nil>")
+	}
 
 	return buffer.String()
 }

--- a/vendor/github.com/zach-klippenstein/goadb/util/error_test.go
+++ b/vendor/github.com/zach-klippenstein/goadb/util/error_test.go
@@ -23,4 +23,22 @@ caused by AssertionError: err2
 caused by err3`
 
 	assert.Equal(t, expected, ErrorWithCauseChain(err))
+
+	assert.Equal(t, "<err=nil>", ErrorWithCauseChain(nil))
+}
+
+func TestCombineErrors(t *testing.T) {
+	assert.NoError(t, CombineErrs("hello", AdbError))
+	assert.NoError(t, CombineErrs("hello", AdbError, nil, nil))
+
+	err1 := errors.New("lulz")
+	err2 := errors.New("fail")
+
+	err := CombineErrs("hello", AdbError, nil, err1, nil)
+	assert.EqualError(t, err, "lulz")
+
+	err = CombineErrs("hello", AdbError, err1, err2)
+	assert.EqualError(t, err, "AdbError: hello")
+	assert.Equal(t, `AdbError: hello
+caused by 2 errors: [lulz ∪ fail]`, ErrorWithCauseChain(err))
 }

--- a/vendor/github.com/zach-klippenstein/goadb/wire/conn.go
+++ b/vendor/github.com/zach-klippenstein/goadb/wire/conn.go
@@ -55,7 +55,7 @@ func (conn *Conn) RoundTripSingleResponse(req []byte) (resp []byte, err error) {
 		return nil, err
 	}
 
-	if err = ReadStatusFailureAsError(conn, string(req)); err != nil {
+	if _, err = conn.ReadStatus(string(req)); err != nil {
 		return nil, err
 	}
 

--- a/vendor/github.com/zach-klippenstein/goadb/wire/scanner_test.go
+++ b/vendor/github.com/zach-klippenstein/goadb/wire/scanner_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"io"
+	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,109 +12,120 @@ import (
 )
 
 func TestReadStatusOkay(t *testing.T) {
-	s := NewScannerString("OKAYd")
-	status, err := s.ReadStatus()
+	s := newEofReader("OKAYd")
+	status, err := readStatusFailureAsError(s, "", readHexLength)
 	assert.NoError(t, err)
-	assert.True(t, status.IsSuccess())
+	assert.False(t, isFailureStatus(status))
 	assertNotEof(t, s)
 }
 
 func TestReadIncompleteStatus(t *testing.T) {
-	s := NewScannerString("oka")
-	_, err := s.ReadStatus()
-	assert.Equal(t, errIncompleteMessage("status", 3, 4), err)
+	s := newEofReader("oka")
+	_, err := readStatusFailureAsError(s, "", readHexLength)
+	assert.EqualError(t, err, "NetworkError: error reading status for ")
+	assert.Equal(t, errIncompleteMessage("", 3, 4), err.(*util.Err).Cause)
+	assertEof(t, s)
+}
+
+func TestReadFailureIncompleteStatus(t *testing.T) {
+	s := newEofReader("FAIL")
+	_, err := readStatusFailureAsError(s, "req", readHexLength)
+	assert.EqualError(t, err, "NetworkError: server returned error for req, but couldn't read the error message")
+	assert.Error(t, err.(*util.Err).Cause)
+	assertEof(t, s)
+}
+
+func TestReadFailureEmptyStatus(t *testing.T) {
+	s := newEofReader("FAIL0000")
+	_, err := readStatusFailureAsError(s, "", readHexLength)
+	assert.EqualError(t, err, "AdbError: server error:  ({Request: ServerMsg:})")
+	assert.NoError(t, err.(*util.Err).Cause)
+	assertEof(t, s)
+}
+
+func TestReadFailureStatus(t *testing.T) {
+	s := newEofReader("FAIL0004fail")
+	_, err := readStatusFailureAsError(s, "", readHexLength)
+	assert.EqualError(t, err, "AdbError: server error: fail ({Request: ServerMsg:fail})")
+	assert.NoError(t, err.(*util.Err).Cause)
+	assertEof(t, s)
+}
+
+func TestReadMessage(t *testing.T) {
+	s := newEofReader("0005hello")
+	msg, err := readMessage(s, readHexLength)
+	assert.NoError(t, err)
+	assert.Len(t, msg, 5)
+	assert.Equal(t, "hello", string(msg))
+	assertEof(t, s)
+}
+
+func TestReadMessageWithExtraData(t *testing.T) {
+	s := newEofReader("0005hellothere")
+	msg, err := readMessage(s, readHexLength)
+	assert.NoError(t, err)
+	assert.Len(t, msg, 5)
+	assert.Equal(t, "hello", string(msg))
+	assertNotEof(t, s)
+}
+
+func TestReadLongerMessage(t *testing.T) {
+	s := newEofReader("001b192.168.56.101:5555	device\n")
+	msg, err := readMessage(s, readHexLength)
+	assert.NoError(t, err)
+	assert.Len(t, msg, 27)
+	assert.Equal(t, "192.168.56.101:5555	device\n", string(msg))
+	assertEof(t, s)
+}
+
+func TestReadEmptyMessage(t *testing.T) {
+	s := newEofReader("0000")
+	msg, err := readMessage(s, readHexLength)
+	assert.NoError(t, err)
+	assert.Equal(t, "", string(msg))
+	assertEof(t, s)
+}
+
+func TestReadIncompleteMessage(t *testing.T) {
+	s := newEofReader("0005hel")
+	msg, err := readMessage(s, readHexLength)
+	assert.Error(t, err)
+	assert.Equal(t, errIncompleteMessage("message data", 3, 5), err)
+	assert.Equal(t, "hel\000\000", string(msg))
 	assertEof(t, s)
 }
 
 func TestReadLength(t *testing.T) {
-	s := NewScannerString("000a")
-	l, err := s.readLength()
+	s := newEofReader("000a")
+	l, err := readHexLength(s)
 	assert.NoError(t, err)
 	assert.Equal(t, 10, l)
 	assertEof(t, s)
 }
 
-func TestReadIncompleteLength(t *testing.T) {
-	s := NewScannerString("aaa")
-	_, err := s.readLength()
+func TestReadLengthIncompleteLength(t *testing.T) {
+	s := newEofReader("aaa")
+	_, err := readHexLength(s)
 	assert.Equal(t, errIncompleteMessage("length", 3, 4), err)
 	assertEof(t, s)
 }
 
-func TestReadMessage(t *testing.T) {
-	s := NewScannerString("0005hello")
-	msg, err := ReadMessageString(s)
-	assert.NoError(t, err)
-	assert.Len(t, msg, 5)
-	assert.Equal(t, "hello", msg)
-	assertEof(t, s)
-}
-
-func TestReadMessageWithExtraData(t *testing.T) {
-	s := NewScannerString("0005hellothere")
-	msg, err := ReadMessageString(s)
-	assert.NoError(t, err)
-	assert.Len(t, msg, 5)
-	assert.Equal(t, "hello", msg)
-	assertNotEof(t, s)
-}
-
-func TestReadLongerMessage(t *testing.T) {
-	s := NewScannerString("001b192.168.56.101:5555	device\n")
-	msg, err := ReadMessageString(s)
-	assert.NoError(t, err)
-	assert.Len(t, msg, 27)
-	assert.Equal(t, "192.168.56.101:5555	device\n", msg)
-	assertEof(t, s)
-}
-
-func TestReadEmptyMessage(t *testing.T) {
-	s := NewScannerString("0000")
-	msg, err := ReadMessageString(s)
-	assert.NoError(t, err)
-	assert.Equal(t, "", msg)
-	assertEof(t, s)
-}
-
-func TestReadIncompleteMessage(t *testing.T) {
-	s := NewScannerString("0005hel")
-	msg, err := ReadMessageString(s)
-	assert.Error(t, err)
-	assert.Equal(t, errIncompleteMessage("message data", 3, 5), err)
-	assert.Equal(t, "hel\000\000", msg)
-	assertEof(t, s)
-}
-
-func NewScannerString(str string) *realScanner {
-	return NewScanner(NewEofBuffer(str)).(*realScanner)
-}
-
-// NewEofBuffer returns a bytes.Buffer of str that returns an EOF error
-// at the end of input, instead of just returning 0 bytes read.
-func NewEofBuffer(str string) *TestReader {
-	limitReader := io.LimitReader(bytes.NewBufferString(str), int64(len(str)))
-	bufReader := bufio.NewReader(limitReader)
-	return &TestReader{bufReader}
-}
-
-func assertEof(t *testing.T, s *realScanner) {
-	msg, err := s.ReadMessage()
+func assertEof(t *testing.T, r io.Reader) {
+	msg, err := readMessage(r, readHexLength)
 	assert.True(t, util.HasErrCode(err, util.ConnectionResetError))
 	assert.Nil(t, msg)
 }
 
-func assertNotEof(t *testing.T, s *realScanner) {
-	n, err := s.reader.Read(make([]byte, 1))
+func assertNotEof(t *testing.T, r io.Reader) {
+	n, err := r.Read(make([]byte, 1))
 	assert.Equal(t, 1, n)
 	assert.NoError(t, err)
 }
 
-// TestReader is a wrapper around a bufio.Reader that implements io.Closer.
-type TestReader struct {
-	*bufio.Reader
-}
-
-func (b *TestReader) Close() error {
-	// No-op.
-	return nil
+// newEofBuffer returns a bytes.Buffer of str that returns an EOF error
+// at the end of input, instead of just returning 0 bytes read.
+func newEofReader(str string) io.ReadCloser {
+	limitReader := io.LimitReader(bytes.NewBufferString(str), int64(len(str)))
+	bufReader := bufio.NewReader(limitReader)
+	return ioutil.NopCloser(bufReader)
 }

--- a/vendor/github.com/zach-klippenstein/goadb/wire/sync_conn.go
+++ b/vendor/github.com/zach-klippenstein/goadb/wire/sync_conn.go
@@ -1,9 +1,10 @@
-// TODO(z): Write SyncSender.SendBytes().
 package wire
+
+import "github.com/zach-klippenstein/goadb/util"
 
 const (
 	// Chunks cannot be longer than 64k.
-	MaxChunkSize = 64 * 1024
+	SyncMaxChunkSize = 64 * 1024
 )
 
 /*
@@ -27,4 +28,10 @@ Modification time seems to be the Unix timestamp format, i.e. seconds since Epoc
 type SyncConn struct {
 	SyncScanner
 	SyncSender
+}
+
+// Close closes both the sender and the scanner, and returns any errors.
+func (c SyncConn) Close() error {
+	return util.CombineErrs("error closing SyncConn", util.NetworkError,
+		c.SyncScanner.Close(), c.SyncSender.Close())
 }

--- a/vendor/github.com/zach-klippenstein/goadb/wire/sync_sender.go
+++ b/vendor/github.com/zach-klippenstein/goadb/wire/sync_sender.go
@@ -10,14 +10,17 @@ import (
 )
 
 type SyncSender interface {
+	io.Closer
+
 	// SendOctetString sends a 4-byte string.
 	SendOctetString(string) error
 	SendInt32(int32) error
 	SendFileMode(os.FileMode) error
 	SendTime(time.Time) error
 
-	// Sends len(bytes) as an octet, followed by bytes.
-	SendString(str string) error
+	// Sends len(data) as an octet, followed by the bytes.
+	// If data is bigger than SyncMaxChunkSize, it returns an assertion error.
+	SendBytes(data []byte) error
 }
 
 type realSyncSender struct {
@@ -54,17 +57,23 @@ func (s *realSyncSender) SendTime(t time.Time) error {
 		util.NetworkError, "error sending time on sync sender")
 }
 
-func (s *realSyncSender) SendString(str string) error {
-	length := len(str)
-	if length > MaxChunkSize {
+func (s *realSyncSender) SendBytes(data []byte) error {
+	length := len(data)
+	if length > SyncMaxChunkSize {
 		// This limit might not apply to filenames, but it's big enough
 		// that I don't think it will be a problem.
-		return util.AssertionErrorf("str must be <= %d in length", MaxChunkSize)
+		return util.AssertionErrorf("data must be <= %d in length", SyncMaxChunkSize)
 	}
 
 	if err := s.SendInt32(int32(length)); err != nil {
-		return util.WrapErrorf(err, util.NetworkError, "error sending string length on sync sender")
+		return util.WrapErrorf(err, util.NetworkError, "error sending data length on sync sender")
 	}
-	return util.WrapErrorf(writeFully(s.Writer, []byte(str)),
-		util.NetworkError, "error sending string on sync sender")
+	return writeFully(s.Writer, data)
+}
+
+func (s *realSyncSender) Close() error {
+	if closer, ok := s.Writer.(io.Closer); ok {
+		return util.WrapErrorf(closer.Close(), util.NetworkError, "error closing sync sender")
+	}
+	return nil
 }

--- a/vendor/github.com/zach-klippenstein/goadb/wire/sync_test.go
+++ b/vendor/github.com/zach-klippenstein/goadb/wire/sync_test.go
@@ -17,13 +17,6 @@ var (
 	someTimeEncoded = []byte{151, 208, 42, 85}
 )
 
-func TestSyncReadOctetString(t *testing.T) {
-	s := NewSyncScanner(strings.NewReader("helo"))
-	str, err := s.ReadOctetString()
-	assert.NoError(t, err)
-	assert.Equal(t, "helo", str)
-}
-
 func TestSyncSendOctetString(t *testing.T) {
 	var buf bytes.Buffer
 	s := NewSyncSender(&buf)
@@ -67,10 +60,10 @@ func TestSyncReadStringTooShort(t *testing.T) {
 	assert.Equal(t, errIncompleteMessage("bytes", 1, 5), err)
 }
 
-func TestSyncSendString(t *testing.T) {
+func TestSyncSendBytes(t *testing.T) {
 	var buf bytes.Buffer
 	s := NewSyncSender(&buf)
-	err := s.SendString("hello")
+	err := s.SendBytes([]byte("hello"))
 	assert.NoError(t, err)
 	assert.Equal(t, "\005\000\000\000hello", buf.String())
 }

--- a/vendor/github.com/zach-klippenstein/goadb/wire/util.go
+++ b/vendor/github.com/zach-klippenstein/goadb/wire/util.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"regexp"
 
+	"sync"
+
 	"github.com/zach-klippenstein/goadb/util"
 )
 
@@ -20,28 +22,6 @@ type ErrorResponseDetails struct {
 //
 // Old servers send "device not found", and newer ones "device 'serial' not found".
 var deviceNotFoundMessagePattern = regexp.MustCompile(`device( '.*')? not found`)
-
-// Reads the status, and if failure, reads the message and returns it as an error.
-// If the status is success, doesn't read the message.
-// req is just used to populate the AdbError, and can be nil.
-func ReadStatusFailureAsError(s Scanner, req string) error {
-	status, err := s.ReadStatus()
-	if err != nil {
-		return util.WrapErrorf(err, util.NetworkError, "error reading status for %s", req)
-	}
-
-	if !status.IsSuccess() {
-		msg, err := s.ReadMessage()
-		if err != nil {
-			return util.WrapErrorf(err, util.NetworkError,
-				"server returned error for %s, but couldn't read the error message", req)
-		}
-
-		return adbServerError(req, string(msg))
-	}
-
-	return nil
-}
 
 func adbServerError(request string, serverMsg string) error {
 	var msg string
@@ -64,6 +44,15 @@ func adbServerError(request string, serverMsg string) error {
 			ServerMsg: serverMsg,
 		},
 	}
+}
+
+// IsAdbServerErrorMatching returns true if err is an *util.Err with code AdbError and for which
+// predicate returns true when passed Details.ServerMsg.
+func IsAdbServerErrorMatching(err error, predicate func(string) bool) bool {
+	if err, ok := err.(*util.Err); ok && err.Code == util.AdbError {
+		return predicate(err.Details.(ErrorResponseDetails).ServerMsg)
+	}
+	return false
 }
 
 func errIncompleteMessage(description string, actual int, expected int) error {
@@ -92,4 +81,22 @@ func writeFully(w io.Writer, data []byte) error {
 		offset += n
 	}
 	return nil
+}
+
+// MultiCloseable wraps c in a ReadWriteCloser that can be safely closed multiple times.
+func MultiCloseable(c io.ReadWriteCloser) io.ReadWriteCloser {
+	return &multiCloseable{ReadWriteCloser: c}
+}
+
+type multiCloseable struct {
+	io.ReadWriteCloser
+	closeOnce sync.Once
+	err       error
+}
+
+func (c *multiCloseable) Close() error {
+	c.closeOnce.Do(func() {
+		c.err = c.ReadWriteCloser.Close()
+	})
+	return c.err
 }


### PR DESCRIPTION
FileBuffer and AdbFile now support writing.
AdbFileSystem support the Create operation.

Write support is experimental and all filesystem write operations
(including filesystem-level ones like Unlink) can be disabled with
the `--readonly` flag. Since file writes are experimental, this flag
is on by default. To enable write support, pass `--no-readonly`.

This commit closes issue #18.